### PR TITLE
Add graph goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,33 @@ We can express the grandfather relationship as a distinct relation by creating a
 ('Abe,')
 ```
 
-## Data Structures
+## Constraints
 
-`kanren` depends on functions, tuples, dicts, and generators.  There are almost no new data structures/classes in `kanren` so it is simple to integrate into preexisting code.
+`kanren` provides a fully functional constraint system that allows one to restrict unification and object types:
+
+```python
+>>> from kanren.constraints import neq, isinstanceo
+
+>>> run(0, x,
+...     neq(x, 1),  # Not "equal" to 1
+...     neq(x, 3),  # Not "equal" to 3
+...     membero(x, (1, 2, 3)))
+(2,)
+
+>>> from numbers import Integral
+>>> run(0, x,
+...     isinstanceo(x, Integral),  # `x` must be of type `Integral`
+...     membero(x, (1.1, 2, 3.2, 4)))
+(2, 4)
+```
+
+## Graph Relations
+
+`kanren` comes with support for relational graph operations suitable for basic symbolic algebra operations.  See the examples in [`doc/graphs.md`](doc/graphs.md).
 
 ## Extending `kanren`
 
-`kanren` uses [`multipledispatch`](http://github.com/mrocklin/multipledispatch/) and the [`logical-unification` library](https://github.com/pythological/unification) to support pattern matching on user defined types.  Essentially, types that can be unified can be used with most `kanren` goals.  See the [project examples](https://github.com/pythological/unification#examples) for demonstrations of how the collection of unifiable types can be extended to your use case.
+`kanren` uses [`multipledispatch`](http://github.com/mrocklin/multipledispatch/) and the [`logical-unification` library](https://github.com/pythological/unification) to support pattern matching on user defined types.  Essentially, types that can be unified can be used with most `kanren` goals.  See the [`logical-unification` project's examples](https://github.com/pythological/unification#examples) for demonstrations of how arbitrary types can be made unifiable.
 
 ## Installation
 

--- a/doc/graphs.md
+++ b/doc/graphs.md
@@ -1,10 +1,10 @@
 # Relational Graph Manipulation
 
-In this document, we show how `kanren` can be used to perform symbolic algebra graph reductions, expansions, and combinations of the two.
+In this document, we show how `kanren` can be used to perform symbolic algebra operations *relationally*.
 
 ## Setup
 
-First, we import the necessary modules and create a helper function for pretty printing the algebraic expressions:
+First, we import the necessary modules and create a helper function for pretty printing the algebraic expressions.
 
 ```python
 from math import log, exp
@@ -17,9 +17,9 @@ from unification import var
 from etuples.core import etuple, ExpressionTuple
 
 from kanren import run, eq, conde, lall
-from kanren.graph import graph_applyo, reduceo
+from kanren.core import success
+from kanren.graph import walko, reduceo
 from kanren.constraints import isinstanceo
-
 
 # Just some nice formatting
 def etuple_str(self):
@@ -28,40 +28,50 @@ def etuple_str(self):
     else:
         return 'noop'
 
+
 ExpressionTuple.__str__ = etuple_str
 del ExpressionTuple._repr_pretty_
 
 ```
 
-
-Next, we create a simple goal constructor that implements the relations `x + x == 2 * x` and `log(exp(x)) == x`:
+Next, we create a simple goal constructor that implements the algebraic relations `x + x == 2 * x` and `log(exp(x)) == x` and
+constrains the input types to real numbers and expression tuples from the [`etuples`](https://github.com/pythological/etuples) package.
 
 ```python
-def math_reduceo(expanded_term, reduced_term):
+def single_math_reduceo(expanded_term, reduced_term):
     """Construct a goal for some simple math reductions."""
     # Create a logic variable to represent our variable term "x"
     x_lv = var()
     # `conde` is a relational version of Lisp's `cond`/if-else; here, each
     # "branch" pairs the right- and left-hand sides of a replacement rule with
     # the corresponding inputs.
-    return lall(conde(
-                    # add(x, x) == mul(2, x)
-                    [eq(expanded_term, etuple(add, x_lv, x_lv)),
-                     eq(reduced_term, etuple(mul, 2, x_lv))],
-                    # log(exp(x)) == x
-                    [eq(expanded_term, etuple(log, etuple(exp, x_lv))),
-                     eq(reduced_term, x_lv)]),
-                conde([isinstanceo(x_lv, Real)],
-                      [isinstanceo(x_lv, ExpressionTuple)]))
+    return lall(
+        isinstanceo(x_lv, Real),
+        isinstanceo(x_lv, ExpressionTuple),
+        conde(
+            # add(x, x) == mul(2, x)
+            [eq(expanded_term, etuple(add, x_lv, x_lv)),
+             eq(reduced_term, etuple(mul, 2, x_lv))],
+            # log(exp(x)) == x
+            [eq(expanded_term, etuple(log, etuple(exp, x_lv))),
+             eq(reduced_term, x_lv)]),
+    )
 
+```
 
-# Make `math_reduceo` recursive
-fp_math_reduceo = partial(reduceo, math_reduceo)
+In order to obtain "fully reduced" results, we need to turn `math_reduceo` into a fixed-point-producing relation (i.e. recursive).
+```python
+math_reduceo = partial(reduceo, single_math_reduceo)
+```
+
+We also need a relation that walks term graphs specifically (i.e. graphs composed of operator and operand combinations) and necessarily produces its output in the form of expression tuples.
+```python
+term_walko = partial(walko, rator_goal=eq, null_type=ExpressionTuple)
 ```
 
 ## Reductions
 
-The following example is a straight-forward reduction&mdash;i.e. left-to-right applications of the relations in `math_reduceo`&mdash;of the term `add(etuple(add, 3, 3), exp(log(exp(5))))`:
+The following example is a straight-forward reduction&mdash;i.e. left-to-right applications of the relations in `math_reduceo`&mdash;of the term `add(etuple(add, 3, 3), exp(log(exp(5))))`.  This is the direction in which results are normally computed in symbolic algebra libraries.
 
 ```python
 # This is the term we want to reduce
@@ -71,7 +81,7 @@ expanded_term = etuple(add, etuple(add, 3, 3), etuple(exp, etuple(log, etuple(ex
 reduced_term = var()
 
 # Asking for 0 results means all results
-res = run(0, reduced_term, graph_applyo(fp_math_reduceo, expanded_term, reduced_term))
+res = run(3, reduced_term, term_walko(math_reduceo, expanded_term, reduced_term))
 ```
 
 ```python
@@ -82,13 +92,15 @@ add(add(3, 3), exp(log(exp(5)))) == add(mul(2, 3), exp(log(exp(5))))
 ```
 
 ## Expansions
-In this example, we're specifying a "concrete" reduced term (i.e. `mul(2, 5)`) and an "unknown" expanded term (i.e. the logic variable `q_lv`).  We're essentially asking for graphs that would reduce to `mul(2, 5)`.
+
+In this example, we're specifying a grounded reduced term (i.e. `mul(2, 5)`) and an unground expanded term (i.e. the logic variable `q_lv`).  We're essentially asking for *graphs that would reduce to `mul(2, 5)`*.  Naturally, there are infinitely many graphs that reduce to `mul(2, 5)`, so we're only going to ask for ten of them; nevertheless, miniKanren is inherently capable of handling infinitely many results through its use of lazily evaluated goal streams.
+
 ```python
 expanded_term = var()
 reduced_term = etuple(mul, 2, 5)
 
 # Ask for 10 results of `q_lv`
-res = run(10, expanded_term, graph_applyo(math_reduceo, expanded_term, reduced_term))
+res = run(10, expanded_term, term_walko(math_reduceo, expanded_term, reduced_term))
 ```
 ```python
 >>> rjust = max(map(lambda x: len(str(x)), res))
@@ -106,27 +118,78 @@ mul(log(exp(log(exp(log(exp(2)))))), log(exp(5))) == mul(2, 5)
 ```
 
 ## Expansions _and_ Reductions
-Now, we set both terms to "unknowns".
+Now, we set **both** term graphs to unground logic variables.
+
 ```python
 expanded_term = var()
-reduced_term = var('r')
+reduced_term = var()
 
 res = run(10, [expanded_term, reduced_term],
-          graph_applyo(math_reduceo, expanded_term, reduced_term))
+          term_walko(math_reduceo, expanded_term, reduced_term))
 ```
 
 ```python
 >>> rjust = max(map(lambda x: len(str(x[0])), res))
 >>> print('\n'.join((f'{str(e):>{rjust}} == {str(r)}' for e, r in res)))
-                     add(~_3289, ~_3289) == mul(2, ~_3289)
-           log(exp(add(~_3293, ~_3293))) == mul(2, ~_3293)
-                                    noop == noop
-add(mul(2, ~_3320), add(~_3320, ~_3320)) == mul(2, mul(2, ~_3320))
-                        log(exp(~_3289)) == ~_3289
- log(exp(log(exp(add(~_3328, ~_3328))))) == mul(2, ~_3328)
-                                ~_3297() == ~_3297()
- log(log(exp(exp(add(~_3338, ~_3338))))) == mul(2, ~_3338)
-                          log(exp(noop)) == noop
-                          ~_3297(~_3333) == ~_3297(~_3333)
+                                        add(~_2291, ~_2291) == mul(2, ~_2291)
+                                                   ~_2288() == ~_2288()
+                              log(exp(add(~_2297, ~_2297))) == mul(2, ~_2297)
+                                ~_2288(add(~_2303, ~_2303)) == ~_2288(mul(2, ~_2303))
+                    log(exp(log(exp(add(~_2309, ~_2309))))) == mul(2, ~_2309)
+                                             ~_2288(~_2294) == ~_2288(~_2294)
+          log(exp(log(exp(log(exp(add(~_2315, ~_2315))))))) == mul(2, ~_2315)
+                                           ~_2288(~_2300()) == ~_2288(~_2300())
+log(exp(log(exp(log(exp(log(exp(add(~_2325, ~_2325))))))))) == mul(2, ~_2325)
+                        ~_2288(~_2294, add(~_2331, ~_2331)) == ~_2288(~_2294, mul(2, ~_2331))
 ```
-The symbols prefixed by `~` are logic variables, so a result like `add(~_3289, ~3289)` basically means `add(x, x)` for some variable `x`.
+
+The symbols prefixed by `~` are the string form of logic variables, so a result like `add(~_2291, ~_2291)` essentially means `add(x, x)` for some variable `x`.  In this instance, miniKanren has used our algebraic relations in `math_reduceo` to produce more relations&mdash;even some with variable operators with multiple arities!
+
+With additional goals, we can narrow-in on very specific types of expressions.  In the following, we state that `expanded_term` must be the [`cons`](https://github.com/pythological/python-cons) of a `log` and logic variable (i.e. anything else).  In other words, we're stating that the operator of `expanded_term` must be a `log`, or that we want all expressions expanding to a `log`.
+
+```python
+from kanren.goals import conso
+
+res = run(10, [expanded_term, reduced_term],
+          conso(log, var(), expanded_term),
+          term_walko(math_reduceo, expanded_term, reduced_term))
+```
+```python
+>>> rjust = max(map(lambda x: len(str(x[0])), res))
+>>> print('\n'.join((f'{str(e):>{rjust}} == {str(r)}' for e, r in res)))
+                              log(exp(add(~_2344, ~_2344))) == mul(2, ~_2344)
+                                                      log() == log()
+                                    log(exp(~reduced_2285)) == ~reduced_2285
+                                   log(add(~_2354, ~_2354)) == log(mul(2, ~_2354))
+                    log(exp(log(exp(add(~_2360, ~_2360))))) == mul(2, ~_2360)
+                                                log(~_2347) == log(~_2347)
+          log(exp(log(exp(log(exp(add(~_2366, ~_2366))))))) == mul(2, ~_2366)
+                                              log(~_2351()) == log(~_2351())
+log(exp(log(exp(log(exp(log(exp(add(~_2376, ~_2376))))))))) == mul(2, ~_2376)
+                           log(~_2347, add(~_2382, ~_2382)) == log(~_2347, mul(2, ~_2382))
+```
+
+The output contains a nullary `log` function, which isn't a valid expression.  We can restrict this type of output by further stating that the `log` expression's `cdr` term is itself the result of a `cons` and, thus, not an empty sequence.
+
+```python
+exp_term_cdr = var()
+
+res = run(10, [expanded_term, reduced_term],
+          conso(log, exp_term_cdr, expanded_term),
+          conso(var(), var(), exp_term_cdr),
+          term_walko(math_reduceo, expanded_term, reduced_term))
+```
+```python
+>>> rjust = max(map(lambda x: len(str(x[0])), res))
+>>> print('\n'.join((f'{str(e):>{rjust}} == {str(r)}' for e, r in res)))
+                              log(exp(add(~_2457, ~_2457))) == mul(2, ~_2457)
+                                   log(add(~_2467, ~_2467)) == log(mul(2, ~_2467))
+                                           log(exp(~_2446)) == ~_2446
+                                                log(~_2460) == log(~_2460)
+                    log(exp(log(exp(add(~_2477, ~_2477))))) == mul(2, ~_2477)
+                                              log(~_2464()) == log(~_2464())
+          log(exp(log(exp(log(exp(add(~_2487, ~_2487))))))) == mul(2, ~_2487)
+                           log(~_2460, add(~_2493, ~_2493)) == log(~_2460, mul(2, ~_2493))
+log(exp(log(exp(log(exp(log(exp(add(~_2499, ~_2499))))))))) == mul(2, ~_2499)
+                         log(log(exp(add(~_2501, ~_2501)))) == log(mul(2, ~_2501))
+```

--- a/doc/graphs.md
+++ b/doc/graphs.md
@@ -1,0 +1,132 @@
+# Relational Graph Manipulation
+
+In this document, we show how `kanren` can be used to perform symbolic algebra graph reductions, expansions, and combinations of the two.
+
+## Setup
+
+First, we import the necessary modules and create a helper function for pretty printing the algebraic expressions:
+
+```python
+from math import log, exp
+from numbers import Real
+from functools import partial
+from operator import add, mul
+
+from unification import var
+
+from etuples.core import etuple, ExpressionTuple
+
+from kanren import run, eq, conde, lall
+from kanren.graph import graph_applyo, reduceo
+from kanren.constraints import isinstanceo
+
+
+# Just some nice formatting
+def etuple_str(self):
+    if len(self) > 0:
+        return f"{getattr(self[0], '__name__', self[0])}({', '.join(map(str, self[1:]))})"
+    else:
+        return 'noop'
+
+ExpressionTuple.__str__ = etuple_str
+del ExpressionTuple._repr_pretty_
+
+```
+
+
+Next, we create a simple goal constructor that implements the relations `x + x == 2 * x` and `log(exp(x)) == x`:
+
+```python
+def math_reduceo(expanded_term, reduced_term):
+    """Construct a goal for some simple math reductions."""
+    # Create a logic variable to represent our variable term "x"
+    x_lv = var()
+    # `conde` is a relational version of Lisp's `cond`/if-else; here, each
+    # "branch" pairs the right- and left-hand sides of a replacement rule with
+    # the corresponding inputs.
+    return lall(conde(
+                    # add(x, x) == mul(2, x)
+                    [eq(expanded_term, etuple(add, x_lv, x_lv)),
+                     eq(reduced_term, etuple(mul, 2, x_lv))],
+                    # log(exp(x)) == x
+                    [eq(expanded_term, etuple(log, etuple(exp, x_lv))),
+                     eq(reduced_term, x_lv)]),
+                conde([isinstanceo(x_lv, Real)],
+                      [isinstanceo(x_lv, ExpressionTuple)]))
+
+
+# Make `math_reduceo` recursive
+fp_math_reduceo = partial(reduceo, math_reduceo)
+```
+
+## Reductions
+
+The following example is a straight-forward reduction&mdash;i.e. left-to-right applications of the relations in `math_reduceo`&mdash;of the term `add(etuple(add, 3, 3), exp(log(exp(5))))`:
+
+```python
+# This is the term we want to reduce
+expanded_term = etuple(add, etuple(add, 3, 3), etuple(exp, etuple(log, etuple(exp, 5))))
+
+# Create a logic variable to represent the results we want to compute
+reduced_term = var()
+
+# Asking for 0 results means all results
+res = run(0, reduced_term, graph_applyo(fp_math_reduceo, expanded_term, reduced_term))
+```
+
+```python
+>>> print('\n'.join((f'{expanded_term} == {r}' for r in res)))
+add(add(3, 3), exp(log(exp(5)))) == add(mul(2, 3), exp(5))
+add(add(3, 3), exp(log(exp(5)))) == add(add(3, 3), exp(5))
+add(add(3, 3), exp(log(exp(5)))) == add(mul(2, 3), exp(log(exp(5))))
+```
+
+## Expansions
+In this example, we're specifying a "concrete" reduced term (i.e. `mul(2, 5)`) and an "unknown" expanded term (i.e. the logic variable `q_lv`).  We're essentially asking for graphs that would reduce to `mul(2, 5)`.
+```python
+expanded_term = var()
+reduced_term = etuple(mul, 2, 5)
+
+# Ask for 10 results of `q_lv`
+res = run(10, expanded_term, graph_applyo(math_reduceo, expanded_term, reduced_term))
+```
+```python
+>>> rjust = max(map(lambda x: len(str(x)), res))
+>>> print('\n'.join((f'{str(r):>{rjust}} == {reduced_term}' for r in res)))
+                                        add(5, 5) == mul(2, 5)
+                    mul(log(exp(2)), log(exp(5))) == mul(2, 5)
+                              log(exp(add(5, 5))) == mul(2, 5)
+                              mul(2, log(exp(5))) == mul(2, 5)
+                    log(exp(log(exp(add(5, 5))))) == mul(2, 5)
+          mul(log(exp(log(exp(2)))), log(exp(5))) == mul(2, 5)
+          log(exp(log(exp(log(exp(add(5, 5))))))) == mul(2, 5)
+                    mul(2, log(exp(log(exp(5))))) == mul(2, 5)
+log(exp(log(exp(log(exp(log(exp(add(5, 5))))))))) == mul(2, 5)
+mul(log(exp(log(exp(log(exp(2)))))), log(exp(5))) == mul(2, 5)
+```
+
+## Expansions _and_ Reductions
+Now, we set both terms to "unknowns".
+```python
+expanded_term = var()
+reduced_term = var('r')
+
+res = run(10, [expanded_term, reduced_term],
+          graph_applyo(math_reduceo, expanded_term, reduced_term))
+```
+
+```python
+>>> rjust = max(map(lambda x: len(str(x[0])), res))
+>>> print('\n'.join((f'{str(e):>{rjust}} == {str(r)}' for e, r in res)))
+                     add(~_3289, ~_3289) == mul(2, ~_3289)
+           log(exp(add(~_3293, ~_3293))) == mul(2, ~_3293)
+                                    noop == noop
+add(mul(2, ~_3320), add(~_3320, ~_3320)) == mul(2, mul(2, ~_3320))
+                        log(exp(~_3289)) == ~_3289
+ log(exp(log(exp(add(~_3328, ~_3328))))) == mul(2, ~_3328)
+                                ~_3297() == ~_3297()
+ log(log(exp(exp(add(~_3338, ~_3338))))) == mul(2, ~_3338)
+                          log(exp(noop)) == noop
+                          ~_3297(~_3333) == ~_3297(~_3333)
+```
+The symbols prefixed by `~` are logic variables, so a result like `add(~_3289, ~3289)` basically means `add(x, x)` for some variable `x`.

--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -32,6 +32,7 @@ be used in the computer algebra systems SymPy and Theano.
 from unification.utils import transitive_get as walk
 from unification import isvar, var
 
+from cons.core import ConsError
 
 from . import core
 from .core import (
@@ -105,7 +106,7 @@ def makeops(op, lists):
 
     >>> from kanren.assoccomm import makeops
     >>> makeops('add', [(1, 2), (3, 4, 5)])
-    (('add', 1, 2), ('add', 3, 4, 5))
+    (ExpressionTuple(('add', 1, 2)), ExpressionTuple(('add', 3, 4, 5)))
     """
     return tuple(l[0] if len(l) == 1 else build(op, l) for l in lists)
 
@@ -149,7 +150,7 @@ def eq_assoc(u, v, eq=core.eq, n=None):
 
     >>> x = var()
     >>> run(0, x, eq(('add', 1, 2, 3), ('add', 1, x)))
-    (('add', 2, 3),)
+    (ExpressionTuple(('add', 2, 3)),)
     """
     uop, _ = op_args(u)
     vop, _ = op_args(v)
@@ -236,7 +237,7 @@ def op_args(x):
         return None, None
     try:
         return operator(x), arguments(x)
-    except NotImplementedError:
+    except (ConsError, NotImplementedError):
         return None, None
 
 
@@ -261,7 +262,7 @@ def eq_assoccomm(u, v):
     >>> e1 = ('add', 1, 2, 3)
     >>> e2 = ('add', 1, x)
     >>> run(0, x, eq(e1, e2))
-    (('add', 2, 3), ('add', 3, 2))
+    (ExpressionTuple(('add', 2, 3)), ExpressionTuple(('add', 3, 2)))
     """
     uop, uargs = op_args(u)
     vop, vargs = op_args(v)

--- a/kanren/dispatch.py
+++ b/kanren/dispatch.py
@@ -1,6 +1,0 @@
-from multipledispatch import dispatch
-from functools import partial
-
-namespace = dict()
-
-dispatch = partial(dispatch, namespace=namespace)

--- a/kanren/goals.py
+++ b/kanren/goals.py
@@ -191,7 +191,7 @@ def seteq(a, b, eq2=eq):
         return permuteq(a, ts(b), eq2)
 
 
-def goalify(func, name=None):
+def goalify(func, name=None):  # pragma: noqa
     """Convert Python function into kanren goal.
 
     >>> from kanren import run, goalify, var, membero
@@ -208,7 +208,7 @@ def goalify(func, name=None):
     ['int', 'str']
     """
 
-    def funco(inputs, out):
+    def funco(inputs, out):  # pragma: noqa
         if isvar(inputs):
             raise EarlyGoalError()
         else:

--- a/kanren/graph.py
+++ b/kanren/graph.py
@@ -1,0 +1,265 @@
+from functools import partial
+from operator import length_hint
+
+from unification import var, isvar
+from unification import reify
+
+from kanren import eq
+from kanren.core import goaleval
+from kanren.goals import conso, fail
+
+from cons.core import ConsPair, ConsNull
+from etuples.core import ExpressionTuple
+from etuples.dispatch import etuplize
+
+from .core import conde, lall
+
+
+def seq_apply_anyo(relation, l_in, l_out, null_type=False, skip_op=True):
+    """Apply a relation to at least one pair of corresponding elements in two sequences.
+
+    Parameters
+    ----------
+    null_type: optional
+       An object that's a valid cdr for the collection type desired.  If
+       `False` (i.e. the default value), the cdr will be inferred from the
+       inputs, or defaults to an empty list.
+    skip_op: boolean (optional)
+       When both inputs are `etuple`s and this value is `True`, the relation
+       will not be applied to the operators (i.e. the cars) of the inputs.
+    """
+
+    # This is a customized (based on the initial call arguments) goal
+    # constructor
+    def _seq_apply_anyo(relation, l_in, l_out, i_any, null_type, skip_cars=False):
+        def seq_apply_anyo_sub_goal(s):
+
+            nonlocal i_any, null_type
+
+            l_in_rf, l_out_rf = reify((l_in, l_out), s)
+
+            i_car, i_cdr = var(), var()
+            o_car, o_cdr = var(), var()
+
+            conde_branches = []
+
+            if i_any or (isvar(l_in_rf) and isvar(l_out_rf)):
+                # Consider terminating the sequences when we've had at least
+                # one successful goal or when both sequences are logic variables.
+                conde_branches.append([eq(l_in_rf, null_type), eq(l_in_rf, l_out_rf)])
+
+            # Extract the CAR and CDR of each argument sequence; this is how we
+            # iterate through elements of the two sequences.
+            cons_parts_branch = [
+                goaleval(conso(i_car, i_cdr, l_in_rf)),
+                goaleval(conso(o_car, o_cdr, l_out_rf)),
+            ]
+
+            conde_branches.append(cons_parts_branch)
+
+            conde_relation_branches = []
+
+            relation_branch = None
+
+            if not skip_cars:
+                relation_branch = [
+                    # This case tries the relation continues on.
+                    relation(i_car, o_car),
+                    # In this conde clause, we can tell future calls to
+                    # seq_apply_anyo that we've had at least one successful
+                    # application of the relation (otherwise, this clause
+                    # would fail due to the above goal).
+                    _seq_apply_anyo(relation, i_cdr, o_cdr, True, null_type),
+                ]
+
+                conde_relation_branches.append(relation_branch)
+
+            base_branch = [
+                # This is the "base" case; it is used when, for example,
+                # the given relation isn't satisfied.
+                eq(i_car, o_car),
+                _seq_apply_anyo(relation, i_cdr, o_cdr, i_any, null_type),
+            ]
+
+            conde_relation_branches.append(base_branch)
+
+            cons_parts_branch.append(conde(*conde_relation_branches))
+
+            g = conde(*conde_branches)
+            g = goaleval(g)
+
+            yield from g(s)
+
+        return seq_apply_anyo_sub_goal
+
+    def seq_apply_anyo_init_goal(s):
+
+        nonlocal null_type, skip_op
+
+        # We need the `cons` types to match in the end, which involves
+        # using the same `cons`-null (i.e. terminating `cdr`).
+        if null_type is False:
+            l_out_, l_in_ = reify((l_out, l_in), s)
+
+            out_null_type = False
+            if isinstance(l_out_, (ConsPair, ConsNull)):
+                out_null_type = type(l_out_)()
+
+            in_null_type = False
+            if isinstance(l_in_, (ConsPair, ConsNull)):
+                in_null_type = type(l_in_)()
+
+                if out_null_type is not False and not type(in_null_type) == type(
+                    out_null_type
+                ):
+                    yield from fail(s)
+                    return
+
+            null_type = (
+                out_null_type
+                if out_null_type is not False
+                else in_null_type
+                if in_null_type is not False
+                else []
+            )
+
+        g = _seq_apply_anyo(
+            relation,
+            l_in,
+            l_out,
+            False,
+            null_type,
+            skip_cars=isinstance(null_type, ExpressionTuple) and skip_op,
+        )
+        g = goaleval(g)
+
+        yield from g(s)
+
+    return seq_apply_anyo_init_goal
+
+
+def reduceo(relation, in_term, out_term):
+    """Relate a term and the fixed-point of that term under a given relation.
+
+    This includes the "identity" relation.
+    """
+
+    def reduceo_goal(s):
+
+        nonlocal in_term, out_term
+
+        in_term_rf, out_term_rf = reify((in_term, out_term), s)
+
+        # The result of reducing the input graph once
+        term_rdcd = var()
+
+        # Are we working "backward" and (potentially) "expanding" a graph
+        # (e.g. when the relation is a reduction rule)?
+        is_expanding = isvar(in_term_rf)
+
+        # One application of the relation assigned to `term_rdcd`
+        single_apply_g = (relation, in_term, term_rdcd)
+
+        # Assign/equate (unify, really) the result of a single application to
+        # the "output" term.
+        single_res_g = eq(term_rdcd, out_term)
+
+        # Recurse into applications of the relation (well, produce a goal that
+        # will do that)
+        another_apply_g = reduceo(relation, term_rdcd, out_term)
+
+        # We want the fixed-point value to show up in the stream output
+        # *first*, but that requires some checks.
+        if is_expanding:
+            # When an un-reduced term is a logic variable (e.g. we're
+            # "expanding"), we can't go depth first.
+            # We need to draw the association between (i.e. unify) the reduced
+            # and expanded terms ASAP, in order to produce finite
+            # expanded graphs first and yield results.
+            #
+            # In other words, there's no fixed-point to produce in this
+            # situation.  Instead, for example, we have to produce an infinite
+            # stream of terms that have `out_term` as a fixed point.
+            # g = conde([single_res_g, single_apply_g],
+            #           [another_apply_g, single_apply_g])
+            g = lall(conde([single_res_g], [another_apply_g]), single_apply_g)
+        else:
+            # Run the recursion step first, so that we get the fixed-point as
+            # the first result
+            g = lall(single_apply_g, conde([another_apply_g], [single_res_g]))
+
+        g = goaleval(g)
+        yield from g(s)
+
+    return reduceo_goal
+
+
+def graph_applyo(
+    relation,
+    in_graph,
+    out_graph,
+    preprocess_graph=partial(etuplize, shallow=True, return_bad_args=True),
+):
+    """Apply a relation to a graph and its subgraphs.
+
+    Parameters
+    ----------
+    relation: callable
+      A relation to apply on a graph and its subgraphs.
+    in_graph: object
+      The graph for which the left-hand side of a binary relation holds.
+    out_graph: object
+      The graph for which the right-hand side of a binary relation holds.
+    preprocess_graph: callable (optional)
+      A unary function that produces an iterable upon which `seq_apply_anyo`
+      can be applied in order to traverse a graph's subgraphs.  The default
+      function converts the graph to expression-tuple form.
+    """
+
+    if preprocess_graph in (False, None):
+
+        def preprocess_graph(x):
+            return x
+
+    def graph_applyo_goal(s):
+
+        nonlocal in_graph, out_graph
+
+        in_graph_rf, out_graph_rf = reify((in_graph, out_graph), s)
+
+        _gapply = partial(graph_applyo, relation, preprocess_graph=preprocess_graph)
+
+        graph_reduce_gl = (relation, in_graph_rf, out_graph_rf)
+
+        # We need to get the sub-graphs/children of the input graph/node
+        if not isvar(in_graph_rf):
+            in_subgraphs = preprocess_graph(in_graph_rf)
+            in_subgraphs = None if length_hint(in_subgraphs, 0) == 0 else in_subgraphs
+        else:
+            in_subgraphs = in_graph_rf
+
+        if not isvar(out_graph_rf):
+            out_subgraphs = preprocess_graph(out_graph_rf)
+            out_subgraphs = (
+                None if length_hint(out_subgraphs, 0) == 0 else out_subgraphs
+            )
+        else:
+            out_subgraphs = out_graph_rf
+
+        conde_args = ([graph_reduce_gl],)
+
+        # This goal reduces sub-graphs/children of the graph.
+        if in_subgraphs is not None and out_subgraphs is not None:
+            # We will only include it when there actually are children, or when
+            # we're dealing with a logic variable (e.g. and "generating"
+            # children).
+            subgraphs_reduce_gl = seq_apply_anyo(_gapply, in_subgraphs, out_subgraphs)
+
+            conde_args += ([subgraphs_reduce_gl],)
+
+        g = conde(*conde_args)
+
+        g = goaleval(g)
+        yield from g(s)
+
+    return graph_applyo_goal

--- a/kanren/term.py
+++ b/kanren/term.py
@@ -1,22 +1,7 @@
 from unification import unify, reify
 from unification.core import _unify, _reify
 
-from .dispatch import dispatch
-
-
-@dispatch((tuple, list))
-def arguments(seq):
-    return seq[1:]
-
-
-@dispatch((tuple, list))
-def operator(seq):
-    return seq[0]
-
-
-@dispatch(object, (tuple, list))
-def term(op, args):
-    return (op,) + tuple(args)
+from etuples import rator as operator, rands as arguments, apply as term
 
 
 def unifiable_with_term(cls):

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "toolz",
         "cons",
         "multipledispatch",
+        "etuples >= 0.1.1",
         "logical-unification >= 0.3.2",
     ],
     tests_require=["pytest", "sympy"],

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -18,7 +18,7 @@ from kanren.assoccomm import (
     buildo,
     op_args,
 )
-from kanren.dispatch import dispatch
+from kanren.term import operator, arguments, term
 
 a = "assoc_op"
 c = "comm_op"
@@ -56,22 +56,27 @@ class Operator(object):
 Add = Operator("add")
 Mul = Operator("mul")
 
-add = lambda *args: Node(Add, args)
-mul = lambda *args: Node(Mul, args)
+
+def add(*args):
+    return Node(Add, args)
 
 
-@dispatch(Operator, (tuple, list))
-def term(op, args):
+def mul(*args):
+    return Node(Mul, args)
+
+
+@term.register(Operator, (tuple, list))
+def term_Operator(op, args):
     return Node(op, args)
 
 
-@dispatch(Node)
-def arguments(n):
+@arguments.register(Node)
+def arguments_Node(n):
     return n.args
 
 
-@dispatch(Node)
-def operator(n):
+@operator.register(Node)
+def operator_Node(n):
     return n.op
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -8,6 +8,7 @@ from unification.core import _reify
 from cons import cons
 
 from kanren import run, eq, conde
+from kanren.goals import membero
 from kanren.core import lall, goaleval
 from kanren.constraints import (
     ConstrainedState,
@@ -221,6 +222,10 @@ def test_typeo():
     assert run(0, q_lv, typeo([], q_lv)) == (q_lv,)
     # Invalid second arg type (i.e. not a type)
     assert run(0, q_lv, typeo(1, 1)) == ()
+    assert run(0, q_lv, membero(q_lv, (1, "cat", 2.2, "hat")), typeo(q_lv, str)) == (
+        "cat",
+        "hat",
+    )
 
     with raises(ValueError):
         run(0, q_lv, typeo(a_lv, str), typeo(a_lv, int))

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -10,10 +10,8 @@ from kanren.goals import (
     appendo,
     seteq,
     conso,
-    typo,
     nullo,
     itero,
-    isinstanceo,
     permuteq,
     membero,
 )
@@ -51,6 +49,7 @@ def test_conso():
     assert results(conso(1, (2, 3), x)) == ({x: (1, 2, 3)},)
     assert results(conso(x, y, (1, 2, 3))) == ({x: 1, y: (2, 3)},)
     assert results(conso(x, (2, 3), y)) == ({y: (x, 2, 3)},)
+    assert run(0, x, conso(x, y, z), eq(z, (1, 2, 3))) == (1,)
 
     # Confirm that custom types are preserved.
     class mytuple(tuple):
@@ -61,11 +60,32 @@ def test_conso():
 
 
 def test_nullo_itero():
+
+    q_lv, a_lv = var(), var()
+
+    assert run(0, q_lv, conso(1, q_lv, [1]), nullo(q_lv))
+    assert run(0, q_lv, nullo(q_lv), conso(1, q_lv, [1]))
+
+    assert not run(0, q_lv, nullo(q_lv, [], ()))
+    assert run(0, [a_lv, q_lv], nullo(q_lv, a_lv, default_ConsNull=tuple)) == (
+        [(), ()],
+    )
+    assert run(0, [a_lv, q_lv], nullo(a_lv, [], q_lv)) == ([[], []],)
+
+    assert ([],) == run(0, q_lv, nullo(q_lv, []))
+    assert ([],) == run(0, q_lv, nullo([], q_lv))
+    assert (None,) == run(0, q_lv, nullo(None, q_lv))
+    assert (tuple(),) == run(0, q_lv, nullo(tuple(), q_lv))
+    assert (q_lv,) == run(0, q_lv, nullo(tuple(), tuple()))
+    assert ([],) == run(0, q_lv, nullo(var(), q_lv))
+    assert ([],) == run(0, q_lv, nullo(q_lv, var()))
+    assert ([],) == run(0, q_lv, nullo(q_lv, q_lv))
+
     assert isvar(run(0, y, nullo([]))[0])
     assert isvar(run(0, y, nullo(None))[0])
     assert run(0, y, nullo(y))[0] == []
-    assert run(0, y, (conso, var(), y, [1]), nullo(y))[0] == []
-    assert run(0, y, (conso, var(), y, (1,)), nullo(y))[0] == ()
+    assert run(0, y, conso(var(), y, [1]), nullo(y))[0] == []
+    assert run(0, y, conso(var(), y, (1,)), nullo(y))[0] == ()
 
     assert run(1, y, conso(1, x, y), itero(y))[0] == [1]
     assert run(1, y, conso(1, x, y), conso(2, z, x), itero(y))[0] == [1, 2]
@@ -131,25 +151,6 @@ def test_permuteq():
     assert set(run(0, x, permuteq(x, (1, 2, 2)))) == set(
         ((1, 2, 2), (2, 1, 2), (2, 2, 1))
     )
-
-
-def test_typo():
-    assert results(typo(3, int))
-    assert not results(typo(3.3, int))
-    assert run(0, x, membero(x, (1, "cat", 2.2, "hat")), (typo, x, str)) == (
-        "cat",
-        "hat",
-    )
-
-
-def test_isinstanceo():
-    assert results(isinstanceo((3, int), True))
-    assert not results(isinstanceo((3, float), True))
-    assert results(isinstanceo((3, float), False))
-
-
-def test_conso_early():
-    assert run(0, x, (conso, x, y, z), (eq, z, (1, 2, 3))) == (1,)
 
 
 def test_appendo():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,365 @@
+from operator import add, mul
+from functools import partial
+from math import log, exp
+
+import pytest
+
+from unification import var, unify
+
+from kanren import run, eq, conde, lall
+from kanren.constraints import isinstanceo
+
+from etuples.core import etuple, ExpressionTuple
+from kanren.graph import reduceo, seq_apply_anyo, graph_applyo
+
+
+class OrderedFunction(object):
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+    @property
+    def __name__(self):
+        return self.func.__name__
+
+    def __lt__(self, other):
+        return self.__name__ < getattr(other, "__name__", str(other))
+
+    def __gt__(self, other):
+        return self.__name__ > getattr(other, "__name__", str(other))
+
+    def __repr__(self):
+        return self.__name__
+
+
+add = OrderedFunction(add)
+mul = OrderedFunction(mul)
+log = OrderedFunction(log)
+exp = OrderedFunction(exp)
+
+
+ExpressionTuple.__lt__ = (
+    lambda self, other: self < (other,)
+    if isinstance(other, int)
+    else tuple(self) < tuple(other)
+)
+ExpressionTuple.__gt__ = (
+    lambda self, other: self > (other,)
+    if isinstance(other, int)
+    else tuple(self) > tuple(other)
+)
+
+
+def math_reduceo(in_expr, out_expr):
+    """Create a relation for a couple math-based identities."""
+    x_lv = var(prefix="x")
+
+    return lall(
+        conde(
+            [eq(in_expr, etuple(add, x_lv, x_lv)), eq(out_expr, etuple(mul, 2, x_lv))],
+            [eq(in_expr, etuple(log, etuple(exp, x_lv))), eq(out_expr, x_lv)],
+        ),
+        conde(
+            [isinstanceo(in_expr, float)],
+            [isinstanceo(in_expr, int)],
+            [isinstanceo(in_expr, ExpressionTuple)],
+            [isinstanceo(out_expr, float)],
+            [isinstanceo(out_expr, int)],
+            [isinstanceo(out_expr, ExpressionTuple)],
+        ),
+    )
+
+
+def full_math_reduceo(a, b):
+    """Produce all results for repeated applications of the math-based relation."""
+    return (reduceo, math_reduceo, a, b)
+
+
+def fixedp_graph_applyo(r, x, y):
+    return reduceo(partial(graph_applyo, r, preprocess_graph=None), x, y)
+
+
+def test_basics():
+    x_lv = var()
+    res = unify(
+        etuple(log, etuple(exp, etuple(log, 1))), etuple(log, etuple(exp, x_lv))
+    )
+    assert res[x_lv] == etuple(log, 1)
+
+
+def test_reduceo():
+    q_lv = var()
+
+    # Reduce/forward
+    res = run(
+        0, q_lv, full_math_reduceo(etuple(log, etuple(exp, etuple(log, 1))), q_lv)
+    )
+    assert len(res) == 1
+    assert res[0] == etuple(log, 1)
+
+    res = run(
+        0,
+        q_lv,
+        full_math_reduceo(etuple(log, etuple(exp, etuple(log, etuple(exp, 1)))), q_lv),
+    )
+    assert res[0] == 1
+    assert res[1] == etuple(log, etuple(exp, 1))
+
+    # Expand/backward
+    res = run(2, q_lv, full_math_reduceo(q_lv, 1))
+    assert res[0] == etuple(log, etuple(exp, 1))
+    assert res[1] == etuple(log, etuple(exp, etuple(log, etuple(exp, 1))))
+
+
+def test_seq_apply_anyo_types():
+    """Make sure that `applyo` preserves the types between its arguments."""
+    q_lv = var()
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), [1], q_lv))
+    assert res[0] == [1]
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), (1,), q_lv))
+    assert res[0] == (1,)
+    res = run(
+        1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), etuple(1,), q_lv, skip_op=False)
+    )
+    assert res[0] == etuple(1,)
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), q_lv, (1,)))
+    assert res[0] == (1,)
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), q_lv, [1]))
+    assert res[0] == [1]
+    res = run(
+        1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), q_lv, etuple(1), skip_op=False)
+    )
+    assert res[0] == etuple(1)
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), [1, 2], [1, 2]))
+    assert len(res) == 1
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), [1, 2], [1, 3]))
+    assert len(res) == 0
+    res = run(1, q_lv, seq_apply_anyo(lambda x, y: eq(x, y), [1, 2], (1, 2)))
+    assert len(res) == 0
+    res = run(
+        0,
+        q_lv,
+        seq_apply_anyo(
+            lambda x, y: eq(y, etuple(mul, 2, x)), etuple(add, 1, 2), q_lv, skip_op=True
+        ),
+    )
+    assert len(res) == 3
+    assert all(r[0] == add for r in res)
+
+
+def test_seq_apply_anyo_misc():
+    q_lv = var("q")
+
+    assert len(run(0, q_lv, seq_apply_anyo(eq, [1, 2, 3], [1, 2, 3]))) == 1
+
+    assert len(run(0, q_lv, seq_apply_anyo(eq, [1, 2, 3], [1, 3, 3]))) == 0
+
+    def one_to_threeo(x, y):
+        return conde([eq(x, 1), eq(y, 3)])
+
+    res = run(0, q_lv, seq_apply_anyo(one_to_threeo, [1, 2, 4, 1, 4, 1, 1], q_lv))
+
+    assert res[0] == [3, 2, 4, 3, 4, 3, 3]
+
+    assert (
+        len(
+            run(4, q_lv, seq_apply_anyo(math_reduceo, [etuple(mul, 2, var("x"))], q_lv))
+        )
+        == 0
+    )
+
+    test_res = run(4, q_lv, seq_apply_anyo(math_reduceo, [etuple(add, 2, 2), 1], q_lv))
+    assert test_res == ([etuple(mul, 2, 2), 1],)
+
+    test_res = run(4, q_lv, seq_apply_anyo(math_reduceo, [1, etuple(add, 2, 2)], q_lv))
+    assert test_res == ([1, etuple(mul, 2, 2)],)
+
+    test_res = run(4, q_lv, seq_apply_anyo(math_reduceo, q_lv, var("z")))
+    assert all(isinstance(r, list) for r in test_res)
+
+    test_res = run(4, q_lv, seq_apply_anyo(math_reduceo, q_lv, var("z"), tuple()))
+    assert all(isinstance(r, tuple) for r in test_res)
+
+
+@pytest.mark.parametrize(
+    "test_input, test_output",
+    [
+        ([], ()),
+        ([1], ()),
+        ([etuple(add, 1, 1),], ([etuple(mul, 2, 1)],)),
+        ([1, etuple(add, 1, 1)], ([1, etuple(mul, 2, 1)],)),
+        ([etuple(add, 1, 1), 1], ([etuple(mul, 2, 1), 1],)),
+        (
+            [etuple(mul, 2, 1), etuple(add, 1, 1), 1],
+            ([etuple(mul, 2, 1), etuple(mul, 2, 1), 1],),
+        ),
+        (
+            [etuple(add, 1, 1), etuple(log, etuple(exp, 5)),],
+            (
+                [etuple(mul, 2, 1), 5],
+                [etuple(add, 1, 1), 5],
+                [etuple(mul, 2, 1), etuple(log, etuple(exp, 5))],
+            ),
+        ),
+    ],
+)
+def test_seq_apply_anyo(test_input, test_output):
+    """Test `seq_apply_anyo` with fully ground terms (i.e. no logic variables)."""
+    q_lv = var()
+    test_res = run(0, q_lv, (seq_apply_anyo, full_math_reduceo, test_input, q_lv))
+
+    assert len(test_res) == len(test_output)
+
+    test_res = sorted(test_res)
+    test_output = sorted(test_output)
+    # Make sure the first result matches.
+    # TODO: This is fairly implementation-specific (i.e. dependent on the order
+    # in which `condeseq` returns results).
+    if len(test_output) > 0:
+        assert test_res[0] == test_output[0]
+
+    # Make sure all the results match.
+    # TODO: If we want to avoid fixing the output order, convert the lists to
+    # tuples and add everything to a set, then compare.
+    assert test_res == test_output
+
+
+def test_seq_apply_anyo_reverse():
+    """Test `seq_apply_anyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
+    # Unbounded reverse
+    q_lv = var()
+    rev_input = [etuple(mul, 2, 1)]
+    test_res = run(4, q_lv, (seq_apply_anyo, math_reduceo, q_lv, rev_input))
+    assert test_res == (
+        [etuple(add, 1, 1)],
+        [etuple(log, etuple(exp, etuple(mul, 2, 1)))],
+    )
+
+    # Guided reverse
+    test_res = run(
+        4,
+        q_lv,
+        (seq_apply_anyo, math_reduceo, [etuple(add, q_lv, 1)], [etuple(mul, 2, 1)]),
+    )
+
+    assert test_res == (1,)
+
+
+def test_graph_applyo_misc():
+    q_lv = var("q")
+    expr = etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1))
+    assert len(run(0, q_lv, graph_applyo(eq, expr, expr, preprocess_graph=None))) == 1
+
+    expr2 = etuple(add, etuple(mul, 2, 1), etuple(add, 2, 1))
+    assert len(run(0, q_lv, graph_applyo(eq, expr, expr2, preprocess_graph=None))) == 0
+
+    assert (
+        len(run(0, q_lv, graph_applyo(eq, etuple(), etuple(), preprocess_graph=None)))
+        == 1
+    )
+
+    def one_to_threeo(x, y):
+        return conde([eq(x, 1), eq(y, 3)])
+
+    res = run(
+        0,
+        q_lv,
+        graph_applyo(
+            one_to_threeo,
+            [1, [1, 2, 4], 2, [[4, 1, 1]], 1],
+            q_lv,
+            preprocess_graph=None,
+        ),
+    )
+
+    assert res[0] == [3, [3, 2, 4], 2, [[4, 3, 3]], 3]
+
+
+@pytest.mark.parametrize(
+    "test_input, test_output",
+    [
+        (1, ()),
+        (etuple(add, 1, 1), (etuple(mul, 2, 1),)),
+        (
+            etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1)),
+            (
+                etuple(mul, 2, etuple(mul, 2, 1)),
+                etuple(add, etuple(mul, 2, 1), etuple(mul, 2, 1)),
+            ),
+        ),
+        (
+            etuple(add, etuple(mul, etuple(log, etuple(exp, 2)), 1), etuple(add, 1, 1)),
+            (
+                etuple(mul, 2, etuple(mul, 2, 1)),
+                etuple(add, etuple(mul, 2, 1), etuple(mul, 2, 1)),
+                etuple(
+                    add, etuple(mul, etuple(log, etuple(exp, 2)), 1), etuple(mul, 2, 1)
+                ),
+                etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1)),
+            ),
+        ),
+    ],
+)
+def test_graph_applyo(test_input, test_output):
+    """Test `graph_applyo` with fully ground terms (i.e. no logic variables)."""
+
+    q_lv = var()
+    test_res = run(
+        len(test_output), q_lv, fixedp_graph_applyo(full_math_reduceo, test_input, q_lv)
+    )
+
+    assert len(test_res) == len(test_output)
+
+    test_res = sorted(test_res)
+    test_output = sorted(test_output)
+
+    # Make sure the first result matches.
+    if len(test_output) > 0:
+        assert test_res[0] == test_output[0]
+
+    # Make sure all the results match.
+    assert set(test_res) == set(test_output)
+
+
+def test_graph_applyo_reverse():
+    """Test `graph_applyo` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""
+    q_lv = var("q")
+
+    test_res = run(2, q_lv, fixedp_graph_applyo(math_reduceo, q_lv, 5))
+    assert test_res == (
+        etuple(log, etuple(exp, 5)),
+        etuple(log, etuple(exp, etuple(log, etuple(exp, 5)))),
+    )
+    assert all(e.eval_obj == 5.0 for e in test_res)
+
+    # Make sure we get some variety in the results
+    test_res = run(2, q_lv, fixedp_graph_applyo(math_reduceo, q_lv, etuple(mul, 2, 5)))
+    assert test_res == (
+        # Expansion of the term's root
+        etuple(add, 5, 5),
+        # Expansion in the term's arguments
+        # etuple(mul, etuple(log, etuple(exp, 2)), etuple(log, etuple(exp, 5))),
+        # Two step expansion at the root
+        etuple(log, etuple(exp, etuple(add, 5, 5))),
+        # Expansion into a sub-term
+        # etuple(mul, 2, etuple(log, etuple(exp, 5)))
+    )
+    assert all(e.eval_obj == 10.0 for e in test_res)
+
+    r_lv = var("r")
+    test_res = run(4, [q_lv, r_lv], fixedp_graph_applyo(math_reduceo, q_lv, r_lv))
+    expect_res = (
+        [etuple(add, 1, 1), etuple(mul, 2, 1)],
+        [etuple(log, etuple(exp, etuple(add, 1, 1))), etuple(mul, 2, 1)],
+        [etuple(), etuple()],
+        [
+            etuple(add, etuple(mul, 2, 1), etuple(add, 1, 1)),
+            etuple(mul, 2, etuple(mul, 2, 1)),
+        ],
+    )
+    assert list(
+        unify(a1, a2) and unify(b1, b2)
+        for [a1, b1], [a2, b2] in zip(test_res, expect_res)
+    )


### PR DESCRIPTION
- `map_anyo` applies a goal to all elements in a list, succeeding
if at least one is found successful.
- `reduceo` applies a goal recursively until a fixed-point is reached.
- `walko` applies a goal throughout a graph.

Closes #9.