### PR TITLE
Improve and add basic miniKanren goals

### DIFF
--- a/examples/prime.py
+++ b/examples/prime.py
@@ -6,8 +6,8 @@ import pytest
 from unification import isvar
 
 from kanren import membero
-from kanren.core import (success, fail, var, run,
-                         condeseq, eq)
+from kanren.core import succeed, fail, var, run, condeseq, eq
+
 try:
     import sympy.ntheory.generate as sg
 except ImportError:
@@ -19,7 +19,7 @@ def primo(x):
     if isvar(x):
         return condeseq([(eq, x, p)] for p in map(sg.prime, it.count(1)))
     else:
-        return success if sg.isprime(x) else fail
+        return succeed if sg.isprime(x) else fail
 
 
 def test_primo():

--- a/kanren/__init__.py
+++ b/kanren/__init__.py
@@ -1,11 +1,21 @@
 # flake8: noqa
 """kanren is a Python library for logic and relational programming."""
-from __future__ import absolute_import
-
 from unification import unify, reify, unifiable, var, isvar, vars, variables, Var
 
 from .core import run, eq, conde, lall, lany
-from .goals import seteq, permuteo, permuteq, goalify, membero
+from .goals import (
+    heado,
+    tailo,
+    conso,
+    nullo,
+    itero,
+    appendo,
+    rembero,
+    permuteo,
+    permuteq,
+    membero,
+    goalify,
+)
 from .facts import Relation, fact, facts
 from .term import arguments, operator, term, unifiable_with_term
 

--- a/kanren/__init__.py
+++ b/kanren/__init__.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from unification import unify, reify, unifiable, var, isvar, vars, variables, Var
 
 from .core import run, eq, conde, lall, lany
-from .goals import seteq, permuteq, goalify, membero
+from .goals import seteq, permuteo, permuteq, goalify, membero
 from .facts import Relation, fact, facts
 from .term import arguments, operator, term, unifiable_with_term
 

--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -107,7 +107,7 @@ def makeops(op, lists):
 
     >>> from kanren.assoccomm import makeops
     >>> makeops('add', [(1, 2), (3, 4, 5)])
-    (ExpressionTuple(('add', 1, 2)), ExpressionTuple(('add', 3, 4, 5)))
+    (('add', 1, 2), ('add', 3, 4, 5))
     """
     return tuple(l[0] if len(l) == 1 else build(op, l) for l in lists)
 
@@ -151,7 +151,7 @@ def eq_assoc(u, v, eq=core.eq, n=None):
 
     >>> x = var()
     >>> run(0, x, eq(('add', 1, 2, 3), ('add', 1, x)))
-    (ExpressionTuple(('add', 2, 3)),)
+    (('add', 2, 3),)
     """
     uop, _ = op_args(u)
     vop, _ = op_args(v)
@@ -282,7 +282,7 @@ def eq_assoccomm(u, v):
     >>> e1 = ('add', 1, 2, 3)
     >>> e2 = ('add', 1, x)
     >>> run(0, x, eq(e1, e2))
-    (ExpressionTuple(('add', 2, 3)), ExpressionTuple(('add', 3, 2)))
+    (('add', 2, 3), ('add', 3, 2))
     """
     uop, uargs = op_args(u)
     vop, vargs = op_args(v)

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -186,6 +186,15 @@ def everyg(predicate, coll):
     return (lall,) + tuple((predicate, x) for x in coll)
 
 
+def Zzz(gctor, *args, **kwargs):
+    """Create an inverse-η-delay for a goal."""
+
+    def Zzz_goal(S):
+        yield from goaleval(gctor(*args, **kwargs))(S)
+
+    return Zzz_goal
+
+
 def run_all(n, x, *goals, results_filter=None):
     """Run a logic program and obtain n solutions that satisfy the given goals.
 

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -186,6 +186,22 @@ def everyg(predicate, coll):
     return (lall,) + tuple((predicate, x) for x in coll)
 
 
+def ifa(g1, g2):
+    """Create a goal operator that returns the first stream unless it fails."""
+
+    def ifa_goal(S):
+        g1_stream = goaleval(g1)(S)
+        S_new = next(g1_stream, None)
+
+        if S_new is None:
+            yield from goaleval(g2)(S)
+        else:
+            yield S_new
+            yield from g1_stream
+
+    return ifa_goal
+
+
 def Zzz(gctor, *args, **kwargs):
     """Create an inverse-η-delay for a goal."""
 

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -11,7 +11,7 @@ def fail(s):
     return iter(())
 
 
-def success(s):
+def succeed(s):
     return iter((s,))
 
 
@@ -55,7 +55,7 @@ def lallgreedy(*goals):
 
     """
     if not goals:
-        return success
+        return succeed
     if len(goals) == 1:
         return goals[0]
 
@@ -74,7 +74,7 @@ def lallgreedy(*goals):
 def lallfirst(*goals):
     """Construct a logical all that runs goals one at a time."""
     if not goals:
-        return success
+        return succeed
     if len(goals) == 1:
         return goals[0]
 

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -1,9 +1,10 @@
-import itertools as it
+from itertools import tee
 from functools import partial
-from .util import dicthash, interleave, take, multihash, unique, evalt
-from toolz import groupby, map
 
+from toolz import groupby, map
 from unification import reify, unify
+
+from .util import dicthash, interleave, take, multihash, unique, evalt
 
 
 def fail(s):
@@ -182,7 +183,7 @@ def lanyseq(goals):
     """Construct a logical any with a possibly infinite number of goals."""
 
     def anygoal(s):
-        anygoal.goals, local_goals = it.tee(anygoal.goals)
+        anygoal.goals, local_goals = tee(anygoal.goals)
 
         def f(goals):
             for goal in goals:

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -293,3 +293,24 @@ def goaleval(goal):
     if isinstance(goal, tuple):  # goal is not yet evaluated like (eq, x, 1)
         return find_fixed_point(evalt, goal)
     raise TypeError("Expected either function or tuple")
+
+
+def dbgo(*args, msg=None):  # pragma: no cover
+    """Construct a goal that sets a debug trace and prints reified arguments."""
+    from pprint import pprint
+
+    def dbgo_goal(S):
+        nonlocal args
+        args = reify(args, S)
+
+        if msg is not None:
+            print(msg)
+
+        pprint(args)
+
+        import pdb
+
+        pdb.set_trace()
+        yield S
+
+    return dbgo_goal

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -50,18 +50,9 @@ def lall(*goals):
 def lallgreedy(*goals):
     """Construct a logical all that greedily evaluates each goals in the order provided.
 
-    Note that this may raise EarlyGoalError when the ordering of the
-    goals is incorrect. It is faster than lall, but should be used
-    with care.
+    Note that this may raise EarlyGoalError when the ordering of the goals is
+    incorrect. It is faster than lall, but should be used with care.
 
-    >>> from kanren import eq, run, membero, var
-    >>> x, y = var('x'), var('y')
-    >>> run(0, x, lallgreedy((eq, y, set([1]))), (membero, x, y))
-    (1,)
-    >>> run(0, x, lallgreedy((membero, x, y), (eq, y, {1})))  # doctest: +SKIP
-    Traceback (most recent call last):
-      ...
-    kanren.core.EarlyGoalError
     """
     if not goals:
         return success
@@ -81,16 +72,7 @@ def lallgreedy(*goals):
 
 
 def lallfirst(*goals):
-    """Construct a logical all that runs goals one at a time.
-
-    >>> from kanren import membero, var
-    >>> x = var('x')
-    >>> g = lallfirst(membero(x, (1,2,3)), membero(x, (2,3,4)))
-    >>> tuple(g({}))
-    ({~x: 2}, {~x: 3})
-    >>> tuple(lallfirst()({}))
-    ({},)
-    """
+    """Construct a logical all that runs goals one at a time."""
     if not goals:
         return success
     if len(goals) == 1:
@@ -117,14 +99,7 @@ def lallfirst(*goals):
 
 
 def lany(*goals):
-    """Construct a logical any goal.
-
-    >>> from kanren import lany, membero, var
-    >>> x = var('x')
-    >>> g = lany(membero(x, (1,2,3)), membero(x, (2,3,4)))
-    >>> tuple(g({}))
-    ({~x: 1}, {~x: 2}, {~x: 3}, {~x: 4})
-    """
+    """Construct a logical any goal."""
     if len(goals) == 1:
         return goals[0]
     return lanyseq(goals)

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -186,7 +186,7 @@ def everyg(predicate, coll):
     return (lall,) + tuple((predicate, x) for x in coll)
 
 
-def run(n, x, *goals):
+def run_all(n, x, *goals, results_filter=None):
     """Run a logic program and obtain n solutions that satisfy the given goals.
 
     >>> from kanren import run, var, eq
@@ -207,7 +207,12 @@ def run(n, x, *goals):
         (i.e. `lall`).
     """
     results = map(partial(reify, x), goaleval(lall(*goals))({}))
-    return take(n, unique(results, key=multihash))
+    if results_filter is not None:
+        results = results_filter(results)
+    return take(n, results)
+
+
+run = partial(run_all, results_filter=partial(unique, key=multihash))
 
 
 class EarlyGoalError(Exception):

--- a/kanren/goals.py
+++ b/kanren/goals.py
@@ -13,7 +13,6 @@ from .core import (
     EarlyGoalError,
     conde,
     condeseq,
-    lany,
     lall,
     fail,
     success,
@@ -240,11 +239,20 @@ def goalify(func, name=None):  # pragma: noqa
     return funco
 
 
-def membero(x, coll):
+def membero(x, ls):
     """Construct a goal stating that x is an item of coll."""
-    if not isvar(coll):
-        return (lany,) + tuple((eq, x, item) for item in coll)
-    raise EarlyGoalError()
+
+    def membero_goal(S):
+        nonlocal x, ls
+
+        x_rf, ls_rf = reify((x, ls), S)
+        a, d = var(), var()
+
+        g = lall(conso(a, d, ls), conde([eq(a, x)], [membero(x, d)]))
+
+        yield from goaleval(g)(S)
+
+    return membero_goal
 
 
 def appendo(l, s, out, default_ConsNull=list):

--- a/kanren/goals.py
+++ b/kanren/goals.py
@@ -129,28 +129,6 @@ def itero(l, nullo_refs=None, default_ConsNull=list):
     return itero_goal
 
 
-def seteq(a, b, eq2=eq):
-    """Construct a goal asserting set equality.
-
-    For example (1, 2, 3) set equates to (2, 1, 3)
-
-    >>> from kanren import var, run, seteq
-    >>> x = var()
-    >>> run(0, x, seteq(x, (1, 2)))
-    ((1, 2), (2, 1))
-
-    >>> run(0, x, seteq((2, 1, x), (3, 1, 2)))
-    (3,)
-    """
-    ts = lambda x: tuple(set(x))
-    if not isvar(a) and not isvar(b):
-        return permuteq(ts(a), ts(b), eq2)
-    elif not isvar(a):
-        return permuteq(ts(a), b, eq2)
-    else:  # not isvar(b)
-        return permuteq(a, ts(b), eq2)
-
-
 def membero(x, ls):
     """Construct a goal stating that x is an item of coll."""
 

--- a/kanren/graph.py
+++ b/kanren/graph.py
@@ -7,7 +7,7 @@ from cons.core import ConsError
 
 from etuples import etuple, apply, rands, rator
 
-from .core import eq, conde, lall, goaleval, success, Zzz, fail
+from .core import eq, conde, lall, goaleval, succeed, Zzz, fail
 from .goals import conso, nullo
 
 
@@ -130,7 +130,7 @@ def map_anyo(
 
 
 def vararg_success(*args):
-    return success
+    return succeed
 
 
 def eq_length(u, v, default_ConsNull=list):

--- a/kanren/graph.py
+++ b/kanren/graph.py
@@ -57,6 +57,30 @@ def applyo(o_rator, o_rands, obj):
     return applyo_goal
 
 
+def mapo(relation, a, b, null_type=list):
+    """Apply a relation to corresponding elements in two sequences and succeed if the relation succeeds for all pairs."""
+
+    def mapo_goal(S):
+
+        a_rf, b_rf = reify((a, b), S)
+        b_car, b_cdr = var(), var()
+        a_car, a_cdr = var(), var()
+
+        g = conde(
+            [nullo(a_rf, b_rf, default_ConsNull=null_type)],
+            [
+                conso(a_car, a_cdr, a_rf),
+                conso(b_car, b_cdr, b_rf),
+                relation(a_car, b_car),
+                mapo(relation, a_cdr, b_cdr, null_type=null_type),
+            ],
+        )
+
+        yield from goaleval(g)(S)
+
+    return mapo_goal
+
+
 def map_anyo(relation, l_in, l_out, null_type=list):
     """Apply a relation to corresponding elements in two sequences and succeed if at least one pair succeeds.
 

--- a/kanren/term.py
+++ b/kanren/term.py
@@ -1,7 +1,19 @@
+from collections.abc import Sequence
+
 from unification import unify, reify
 from unification.core import _unify, _reify
 
+from cons.core import cons
+
 from etuples import rator as operator, rands as arguments, apply as term
+
+
+@term.register(object, Sequence)
+def term_Sequence(rator, rands):
+    # Overwrite the default `apply` dispatch function and make it preserve
+    # types
+    res = cons(rator, rands)
+    return res
 
 
 def unifiable_with_term(cls):

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -1,30 +1,29 @@
-from __future__ import absolute_import
-
 import pytest
 
-from unification import reify, var, variables
+from collections.abc import Sequence
 
-from kanren.core import run, goaleval
+from etuples.core import etuple
+
+from cons import cons
+
+from unification import reify, var, variables, isvar, unify
+
+from kanren.core import goaleval, run_all as run
 from kanren.facts import fact
 from kanren.assoccomm import (
     associative,
     commutative,
-    groupsizes_to_partition,
-    assocunify,
+    eq_assoc_args,
     eq_comm,
     eq_assoc,
     eq_assoccomm,
-    assocsized,
+    assoc_args,
     buildo,
     op_args,
+    flatten_assoc_args,
+    assoc_flatten,
 )
 from kanren.term import operator, arguments, term
-
-x, y = var("x"), var("y")
-
-a, c = "assoc_op", "comm_op"
-fact(associative, a)
-fact(commutative, c)
 
 
 class Node(object):
@@ -65,7 +64,7 @@ def mul(*args):
     return Node(Mul, args)
 
 
-@term.register(Operator, (tuple, list))
+@term.register(Operator, Sequence)
 def term_Operator(op, args):
     return Node(op, args)
 
@@ -86,182 +85,494 @@ def results(g, s=None):
     return tuple(goaleval(g)(s))
 
 
+def test_op_args():
+    assert op_args(var()) == (None, None)
+    assert op_args(add(1, 2, 3)) == (Add, (1, 2, 3))
+    assert op_args("foo") == (None, None)
+
+
+def test_buildo():
+    x = var()
+    assert run(0, x, buildo("add", (1, 2, 3), x)) == (("add", 1, 2, 3),)
+    assert run(0, x, buildo(x, (1, 2, 3), ("add", 1, 2, 3))) == ("add",)
+    assert run(0, x, buildo("add", x, ("add", 1, 2, 3))) == ((1, 2, 3),)
+
+
+def test_buildo_object():
+    x = var()
+    assert run(0, x, buildo(Add, (1, 2, 3), x)) == (add(1, 2, 3),)
+    assert run(0, x, buildo(x, (1, 2, 3), add(1, 2, 3))) == (Add,)
+    assert run(0, x, buildo(Add, x, add(1, 2, 3))) == ((1, 2, 3),)
+
+
 def test_eq_comm():
-    assert results(eq_comm(1, 1))
-    assert results(eq_comm((c, 1, 2, 3), (c, 1, 2, 3)))
-    assert results(eq_comm((c, 3, 2, 1), (c, 1, 2, 3)))
-    assert not results(eq_comm((a, 3, 2, 1), (a, 1, 2, 3)))  # not commutative
-    assert not results(eq_comm((3, c, 2, 1), (c, 1, 2, 3)))
-    assert not results(eq_comm((c, 1, 2, 1), (c, 1, 2, 3)))
-    assert not results(eq_comm((a, 1, 2, 3), (c, 1, 2, 3)))
-    assert len(results(eq_comm((c, 3, 2, 1), x))) >= 6
-    assert results(eq_comm(x, y)) == ({x: y},)
+    x, y, z = var(), var(), var()
+
+    commutative.facts.clear()
+    commutative.index.clear()
+
+    comm_op = "comm_op"
+
+    fact(commutative, comm_op)
+
+    assert run(0, True, eq_comm(1, 1)) == (True,)
+    assert run(0, True, eq_comm((comm_op, 1, 2, 3), (comm_op, 1, 2, 3))) == (True,)
+
+    assert run(0, True, eq_comm((comm_op, 3, 2, 1), (comm_op, 1, 2, 3))) == (True,)
+    assert run(0, y, eq_comm((comm_op, 3, y, 1), (comm_op, 1, 2, 3))) == (2,)
+    assert run(0, (x, y), eq_comm((comm_op, x, y, 1), (comm_op, 1, 2, 3))) == (
+        (2, 3),
+        (3, 2),
+    )
+    assert run(0, (x, y), eq_comm((comm_op, 2, 3, 1), (comm_op, 1, x, y))) == (
+        (2, 3),
+        (3, 2),
+    )
+
+    assert not run(
+        0, True, eq_comm(("op", 3, 2, 1), ("op", 1, 2, 3))
+    )  # not commutative
+    assert not run(0, True, eq_comm((3, comm_op, 2, 1), (comm_op, 1, 2, 3)))
+    assert not run(0, True, eq_comm((comm_op, 1, 2, 1), (comm_op, 1, 2, 3)))
+    assert not run(0, True, eq_comm(("op", 1, 2, 3), (comm_op, 1, 2, 3)))
+
+    # Test for variable args
+    res = run(4, (x, y), eq_comm(x, y))
+    exp_res_form = (
+        (etuple(comm_op, x, y), etuple(comm_op, y, x)),
+        (x, y),
+        (etuple(etuple(comm_op, x, y)), etuple(etuple(comm_op, y, x))),
+        (etuple(comm_op, x, y, z), etuple(comm_op, x, z, y)),
+    )
+
+    for a, b in zip(res, exp_res_form):
+        s = unify(a, b)
+        assert s is not False
+        assert all(isvar(i) for i in reify((x, y, z), s))
+
+    # Make sure it can unify single elements
+    assert (3,) == run(0, x, eq_comm((comm_op, 1, 2, 3), (comm_op, 2, x, 1)))
+
+    # `eq_comm` should propagate through
+    assert (3,) == run(
+        0, x, eq_comm(("div", 1, (comm_op, 1, 2, 3)), ("div", 1, (comm_op, 2, x, 1)))
+    )
+    # Now it should not
+    assert () == run(
+        0, x, eq_comm(("div", 1, ("div", 1, 2, 3)), ("div", 1, ("div", 2, x, 1)))
+    )
+
+    expected_res = {(1, 2, 3), (2, 1, 3), (3, 1, 2), (1, 3, 2), (2, 3, 1), (3, 2, 1)}
+    assert expected_res == set(
+        run(0, (x, y, z), eq_comm((comm_op, 1, 2, 3), (comm_op, x, y, z)))
+    )
+    assert expected_res == set(
+        run(0, (x, y, z), eq_comm((comm_op, x, y, z), (comm_op, 1, 2, 3)))
+    )
+    assert expected_res == set(
+        run(
+            0,
+            (x, y, z),
+            eq_comm(("div", 1, (comm_op, 1, 2, 3)), ("div", 1, (comm_op, x, y, z))),
+        )
+    )
+
+    e1 = (comm_op, (comm_op, 1, x), y)
+    e2 = (comm_op, 2, (comm_op, 3, 1))
+    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
+
+    e1 = ((comm_op, 3, 1),)
+    e2 = ((comm_op, 1, x),)
+
+    assert run(0, x, eq_comm(e1, e2)) == (3,)
+
+    e1 = (2, (comm_op, 3, 1))
+    e2 = (y, (comm_op, 1, x))
+
+    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
+
+    e1 = (comm_op, (comm_op, 1, x), y)
+    e2 = (comm_op, 2, (comm_op, 3, 1))
+
+    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
+
+
+@pytest.mark.xfail(reason="`applyo`/`buildo` needs to be a constraint.", strict=True)
+def test_eq_comm_object():
+    x = var("x")
+
+    fact(commutative, Add)
+    fact(associative, Add)
+
+    assert run(0, x, eq_comm(add(1, 2, 3), add(3, 1, x))) == (2,)
+    assert set(run(0, x, eq_comm(add(1, 2), x))) == set((add(1, 2), add(2, 1)))
+    assert set(run(0, x, eq_assoccomm(add(1, 2, 3), add(1, x)))) == set(
+        (add(2, 3), add(3, 2))
+    )
+
+
+def test_flatten_assoc_args():
+    op = "add"
+
+    def op_pred(x):
+        return x == op
+
+    assert list(flatten_assoc_args(op_pred, [op, 1, 2, 3, 4])) == [op, 1, 2, 3, 4]
+    assert list(flatten_assoc_args(op_pred, [op, 1, 2, [op]])) == [op, 1, 2, [op]]
+    assert list(flatten_assoc_args(op_pred, [[op, 1, 2, [op]]])) == [1, 2, [op]]
+
+    res = list(
+        flatten_assoc_args(
+            op_pred, [[1, 2, op], 3, [op, 4, [op, [op]]], [op, 5], 6, op, 7]
+        )
+    )
+    exp_res = [[1, 2, op], 3, 4, [op], 5, 6, op, 7]
+    assert res == exp_res
+
+
+def test_assoc_args():
+    op = "add"
+
+    def op_pred(x):
+        return x == op
+
+    assert tuple(assoc_args(op, (1, 2, 3), 2)) == (((op, 1, 2), 3), (1, (op, 2, 3)),)
+    assert tuple(assoc_args(op, [1, 2, 3], 2)) == ([[op, 1, 2], 3], [1, [op, 2, 3]],)
+    assert tuple(assoc_args(op, (1, 2, 3), 1)) == (
+        ((op, 1), 2, 3),
+        (1, (op, 2), 3),
+        (1, 2, (op, 3)),
+    )
+    assert tuple(assoc_args(op, (1, 2, 3), 3)) == ((1, 2, 3),)
+
+    f_rands = flatten_assoc_args(op_pred, (1, (op, 2, 3)))
+    assert tuple(assoc_args(op, f_rands, 2, ctor=tuple)) == (
+        ((op, 1, 2), 3),
+        (1, (op, 2, 3)),
+    )
+
+
+def test_eq_assoc_args():
+
+    assoc_op = "assoc_op"
+
+    fact(associative, assoc_op)
+
+    assert not run(0, True, eq_assoc_args(assoc_op, (1,), [1], n=None))
+    assert run(0, True, eq_assoc_args(assoc_op, (1,), (1,), n=None)) == (True,)
+    assert run(0, True, eq_assoc_args(assoc_op, (1, 1), (1, 1))) == (True,)
+    assert run(0, True, eq_assoc_args(assoc_op, (1, 2, 3), (1, (assoc_op, 2, 3)))) == (
+        True,
+    )
+    assert run(0, True, eq_assoc_args(assoc_op, (1, (assoc_op, 2, 3)), (1, 2, 3))) == (
+        True,
+    )
+    assert run(
+        0, True, eq_assoc_args(assoc_op, (1, (assoc_op, 2, 3), 4), (1, 2, 3, 4))
+    ) == (True,)
+    assert not run(
+        0, True, eq_assoc_args(assoc_op, (1, 2, 3), (1, (assoc_op, 2, 3), 4))
+    )
+
+    x, y = var(), var()
+
+    assert run(0, True, eq_assoc_args(assoc_op, (x,), (x,), n=None)) == (True,)
+    assert run(0, x, eq_assoc_args(assoc_op, x, (y,), n=None)) == ((y,),)
+    assert run(0, x, eq_assoc_args(assoc_op, (y,), x, n=None)) == ((y,),)
+
+    assert run(0, x, eq_assoc_args(assoc_op, (1, x, 4), (1, 2, 3, 4))) == (
+        (assoc_op, 2, 3),
+    )
+    assert run(0, x, eq_assoc_args(assoc_op, (1, 2, 3, 4), (1, x, 4))) == (
+        (assoc_op, 2, 3),
+    )
+    assert run(0, x, eq_assoc_args(assoc_op, [1, x, 4], [1, 2, 3, 4])) == (
+        [assoc_op, 2, 3],
+    )
+    assert run(0, True, eq_assoc_args(assoc_op, (1, 1), ("other_op", 1, 1))) == ()
+
+    assert run(0, x, eq_assoc_args(assoc_op, (1, 2, 3), x, n=2)) == (
+        ((assoc_op, 1, 2), 3),
+        (1, (assoc_op, 2, 3)),
+    )
+    assert run(0, x, eq_assoc_args(assoc_op, x, (1, 2, 3), n=2)) == (
+        ((assoc_op, 1, 2), 3),
+        (1, (assoc_op, 2, 3)),
+    )
+
+    assert run(0, x, eq_assoc_args(assoc_op, (1, 2, 3), x)) == (
+        ((assoc_op, 1, 2), 3),
+        (1, (assoc_op, 2, 3)),
+        (1, 2, 3),
+    )
+
+    assert () not in run(0, x, eq_assoc_args(assoc_op, (), x, no_ident=True))
+    assert (1,) not in run(0, x, eq_assoc_args(assoc_op, (1,), x, no_ident=True))
+    assert (1, 2, 3) not in run(
+        0, x, eq_assoc_args(assoc_op, (1, 2, 3), x, no_ident=True)
+    )
+
+    assert (
+        run(
+            0,
+            True,
+            eq_assoc_args(
+                assoc_op, (1, (assoc_op, 2, 3)), (1, (assoc_op, 2, 3)), no_ident=True,
+            ),
+        )
+        == ()
+    )
+
+    assert run(
+        0,
+        True,
+        eq_assoc_args(
+            assoc_op, (1, (assoc_op, 2, 3)), ((assoc_op, 1, 2), 3), no_ident=True,
+        ),
+    ) == (True,)
 
 
 def test_eq_assoc():
-    assert results(eq_assoc(1, 1))
-    assert results(eq_assoc((a, 1, 2, 3), (a, 1, 2, 3)))
-    assert not results(eq_assoc((a, 3, 2, 1), (a, 1, 2, 3)))
-    assert results(eq_assoc((a, (a, 1, 2), 3), (a, 1, 2, 3)))
-    assert results(eq_assoc((a, 1, 2, 3), (a, (a, 1, 2), 3)))
+
+    assoc_op = "assoc_op"
+
+    associative.index.clear()
+    associative.facts.clear()
+
+    fact(associative, assoc_op)
+
+    assert run(0, True, eq_assoc(1, 1)) == (True,)
+    assert run(0, True, eq_assoc((assoc_op, 1, 2, 3), (assoc_op, 1, 2, 3))) == (True,)
+    assert not run(0, True, eq_assoc((assoc_op, 3, 2, 1), (assoc_op, 1, 2, 3)))
+    assert run(
+        0, True, eq_assoc((assoc_op, (assoc_op, 1, 2), 3), (assoc_op, 1, 2, 3))
+    ) == (True,)
+    assert run(
+        0, True, eq_assoc((assoc_op, 1, 2, 3), (assoc_op, (assoc_op, 1, 2), 3))
+    ) == (True,)
     o = "op"
-    assert not results(eq_assoc((o, 1, 2, 3), (o, (o, 1, 2), 3)))
+    assert not run(0, True, eq_assoc((o, 1, 2, 3), (o, (o, 1, 2), 3)))
 
-    # See TODO in assocunify
-    gen = results(eq_assoc((a, 1, 2, 3), x, n=2))
-    assert set(g[x] for g in gen).issuperset(
-        set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
-    )
-    gen = results(eq_assoc(x, (a, 1, 2, 3), n=2))
-    assert set(g[x] for g in gen).issuperset(
-        set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
+    x = var()
+    res = run(0, x, eq_assoc((assoc_op, 1, 2, 3), x, n=2))
+    assert res == (
+        (assoc_op, (assoc_op, 1, 2), 3),
+        (assoc_op, 1, 2, 3),
+        (assoc_op, 1, (assoc_op, 2, 3)),
     )
 
+    res = run(0, x, eq_assoc(x, (assoc_op, 1, 2, 3), n=2))
+    assert res == (
+        (assoc_op, (assoc_op, 1, 2), 3),
+        (assoc_op, 1, 2, 3),
+        (assoc_op, 1, (assoc_op, 2, 3)),
+    )
 
-def test_eq_assoccomm():
-    x, y = var(), var()
-    eqac = eq_assoccomm
-    ac = "commassoc_op"
-    fact(commutative, ac)
-    fact(associative, ac)
-    assert results(eqac(1, 1))
-    assert results(eqac((1,), (1,)))
-    assert results(eqac(x, (1,)))
-    assert results(eqac((1,), x))
-    assert results((eqac, 1, 1))
-    assert results(eqac((a, (a, 1, 2), 3), (a, 1, 2, 3)))
-    assert results(eqac((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1))))
-    assert results(eqac((ac, (ac, 1, 2), 3), (ac, 1, 2, 3)))
-    assert results(eqac((ac, 3, (ac, 1, 2)), (ac, 1, 2, 3)))
-    assert not results(eqac((ac, 1, 1), ("other_op", 1, 1)))
-    assert run(0, x, eqac((ac, 3, (ac, 1, 2)), (ac, 1, x, 3))) == (2,)
+    y, z = var(), var()
+
+    # Check results when both arguments are variables
+    res = run(3, (x, y), eq_assoc(x, y))
+    exp_res_form = (
+        (etuple(assoc_op, x, y, z), etuple(assoc_op, etuple(assoc_op, x, y), z)),
+        (x, y),
+        (
+            etuple(etuple(assoc_op, x, y, z)),
+            etuple(etuple(assoc_op, etuple(assoc_op, x, y), z)),
+        ),
+    )
+
+    for a, b in zip(res, exp_res_form):
+        s = unify(a, b)
+        assert s is not False, (a, b)
+        assert all(isvar(i) for i in reify((x, y, z), s))
+
+    # Make sure it works with `cons`
+    res = run(0, (x, y), eq_assoc(cons(x, y), (assoc_op, 1, 2, 3)))
+    assert res == (
+        (assoc_op, ((assoc_op, 1, 2), 3)),
+        (assoc_op, (1, 2, 3)),
+        (assoc_op, (1, (assoc_op, 2, 3))),
+    )
+
+    res = run(1, (x, y), eq_assoc(cons(x, y), (x, z, 2, 3)))
+    assert res == ((assoc_op, ((assoc_op, z, 2), 3)),)
+
+    # Don't use a predicate that can never succeed, e.g.
+    # associative_2 = Relation("associative_2")
+    # run(1, (x, y), eq_assoc(cons(x, y), (x, z), op_predicate=associative_2))
+
+    # Nested expressions should work now
+    expr1 = (assoc_op, 1, 2, (assoc_op, x, 5, 6))
+    expr2 = (assoc_op, (assoc_op, 1, 2), 3, 4, 5, 6)
+    assert run(0, x, eq_assoc(expr1, expr2, n=2)) == ((assoc_op, 3, 4),)
 
 
-def test_expr():
+def test_assoc_flatten():
+
     add = "add"
     mul = "mul"
+
     fact(commutative, add)
     fact(associative, add)
     fact(commutative, mul)
     fact(associative, mul)
 
-    x, y = var("x"), var("y")
+    assert run(
+        0,
+        True,
+        assoc_flatten((mul, 1, (add, 2, 3), (mul, 4, 5)), (mul, 1, (add, 2, 3), 4, 5)),
+    ) == (True,)
+
+    x = var()
+    assert run(0, x, assoc_flatten((mul, 1, (add, 2, 3), (mul, 4, 5)), x),) == (
+        (mul, 1, (add, 2, 3), 4, 5),
+    )
+
+    assert run(
+        0,
+        True,
+        assoc_flatten(
+            ("op", 1, (add, 2, 3), (mul, 4, 5)), ("op", 1, (add, 2, 3), (mul, 4, 5))
+        ),
+    ) == (True,)
+
+    assert run(0, x, assoc_flatten(("op", 1, (add, 2, 3), (mul, 4, 5)), x)) == (
+        ("op", 1, (add, 2, 3), (mul, 4, 5)),
+    )
+
+
+def test_eq_assoccomm():
+    x, y = var(), var()
+
+    ac = "commassoc_op"
+
+    commutative.index.clear()
+    commutative.facts.clear()
+
+    fact(commutative, ac)
+    fact(associative, ac)
+
+    assert run(0, True, eq_assoccomm(1, 1)) == (True,)
+    assert run(0, True, eq_assoccomm((1,), (1,))) == (True,)
+    assert run(0, True, eq_assoccomm(x, (1,))) == (True,)
+    assert run(0, True, eq_assoccomm((1,), x)) == (True,)
+
+    # Assoc only
+    assert run(0, True, eq_assoccomm((ac, 1, (ac, 2, 3)), (ac, (ac, 1, 2), 3))) == (
+        True,
+    )
+    # Commute only
+    assert run(0, True, eq_assoccomm((ac, 1, (ac, 2, 3)), (ac, (ac, 3, 2), 1))) == (
+        True,
+    )
+    # Both
+    assert run(0, True, eq_assoccomm((ac, 1, (ac, 3, 2)), (ac, (ac, 1, 2), 3))) == (
+        True,
+    )
+
+    exp_res = set(
+        (
+            (ac, 1, 3, 2),
+            (ac, 1, 2, 3),
+            (ac, 2, 1, 3),
+            (ac, 2, 3, 1),
+            (ac, 3, 1, 2),
+            (ac, 3, 2, 1),
+            (ac, 1, (ac, 2, 3)),
+            (ac, 1, (ac, 3, 2)),
+            (ac, 2, (ac, 1, 3)),
+            (ac, 2, (ac, 3, 1)),
+            (ac, 3, (ac, 1, 2)),
+            (ac, 3, (ac, 2, 1)),
+            (ac, (ac, 2, 3), 1),
+            (ac, (ac, 3, 2), 1),
+            (ac, (ac, 1, 3), 2),
+            (ac, (ac, 3, 1), 2),
+            (ac, (ac, 1, 2), 3),
+            (ac, (ac, 2, 1), 3),
+        )
+    )
+    assert set(run(0, x, eq_assoccomm((ac, 1, (ac, 2, 3)), x))) == exp_res
+    assert set(run(0, x, eq_assoccomm((ac, 1, 3, 2), x))) == exp_res
+    assert set(run(0, x, eq_assoccomm((ac, 2, (ac, 3, 1)), x))) == exp_res
+    # LHS variations
+    assert set(run(0, x, eq_assoccomm(x, (ac, 1, (ac, 2, 3))))) == exp_res
+
+    assert run(0, (x, y), eq_assoccomm((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1)))) == (
+        (2, 3),
+        (3, 2),
+    )
+
+    assert run(0, True, eq_assoccomm((ac, (ac, 1, 2), 3), (ac, 1, 2, 3))) == (True,)
+    assert run(0, True, eq_assoccomm((ac, 3, (ac, 1, 2)), (ac, 1, 2, 3))) == (True,)
+    assert run(0, True, eq_assoccomm((ac, 1, 1), ("other_op", 1, 1))) == ()
+
+    assert run(0, x, eq_assoccomm((ac, 3, (ac, 1, 2)), (ac, 1, x, 3))) == (2,)
+
+    # Both arguments unground
+    op_lv = var()
+    z = var()
+    res = run(4, (x, y), eq_assoccomm(x, y))
+    exp_res_form = (
+        (etuple(op_lv, x, y), etuple(op_lv, y, x)),
+        (y, y),
+        (etuple(etuple(op_lv, x, y)), etuple(etuple(op_lv, y, x)),),
+        (etuple(op_lv, x, y, z), etuple(op_lv, etuple(op_lv, x, y), z),),
+    )
+
+    for a, b in zip(res, exp_res_form):
+        s = unify(a, b)
+        assert (
+            op_lv not in s
+            or (s[op_lv],) in associative.facts
+            or (s[op_lv],) in commutative.facts
+        )
+        assert s is not False, (a, b)
+        assert all(isvar(i) for i in reify((x, y, z), s))
+
+
+def test_assoccomm_algebra():
+
+    add = "add"
+    mul = "mul"
+
+    commutative.index.clear()
+    commutative.facts.clear()
+    associative.index.clear()
+    associative.facts.clear()
+
+    fact(commutative, add)
+    fact(associative, add)
+    fact(commutative, mul)
+    fact(associative, mul)
+
+    x, y = var(), var()
 
     pattern = (mul, (add, 1, x), y)  # (1 + x) * y
     expr = (mul, 2, (add, 3, 1))  # 2 * (3 + 1)
+
     assert run(0, (x, y), eq_assoccomm(pattern, expr)) == ((3, 2),)
 
 
-def test_deep_commutativity():
-    x, y = var("x"), var("y")
+def test_assoccomm_objects():
 
-    e1 = ((c, 3, 1),)
-    e2 = ((c, 1, x),)
+    commutative.index.clear()
+    commutative.facts.clear()
+    associative.index.clear()
+    associative.facts.clear()
 
-    assert run(0, x, eq_comm(e1, e2)) == (3,)
-
-    e1 = (2, (c, 3, 1))
-    e2 = (y, (c, 1, x))
-
-    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
-
-    e1 = (c, (c, 1, x), y)
-    e2 = (c, 2, (c, 3, 1))
-
-    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
-
-
-def test_groupsizes_to_parition():
-    assert groupsizes_to_partition(2, 3) == [[0, 1], [2, 3, 4]]
-
-
-def test_assocunify():
-    assert tuple(assocunify(1, 1, {}))
-    assert tuple(assocunify((a, 1, 1), (a, 1, 1), {}))
-    assert tuple(assocunify((a, 1, 2, 3), (a, 1, (a, 2, 3)), {}))
-    assert tuple(assocunify((a, 1, (a, 2, 3)), (a, 1, 2, 3), {}))
-    assert tuple(assocunify((a, 1, (a, 2, 3), 4), (a, 1, 2, 3, 4), {}))
-    assert tuple(assocunify((a, 1, x, 4), (a, 1, 2, 3, 4), {})) == ({x: (a, 2, 3)},)
-    assert tuple(assocunify((a, 1, 1), ("other_op", 1, 1), {})) == ()
-
-    assert tuple(assocunify((a, 1, 1), (x, 1, 1), {})) == ({x: a},)
-    assert tuple(assocunify((x, 1, 1), (a, 1, 1), {})) == ({x: a},)
-
-    gen = assocunify((a, 1, 2, 3), x, {}, n=2)
-    assert set(g[x] for g in gen) == set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
-    gen = assocunify(x, (a, 1, 2, 3), {}, n=2)
-    assert set(g[x] for g in gen) == set([(a, (a, 1, 2), 3), (a, 1, (a, 2, 3))])
-
-    gen = assocunify((a, 1, 2, 3), x, {})
-    assert set(g[x] for g in gen) == set(
-        [(a, 1, 2, 3), (a, (a, 1, 2), 3), (a, 1, (a, 2, 3))]
-    )
-
-
-def test_assocsized():
-    add = "add"
-    assert set(assocsized(add, (1, 2, 3), 2)) == set(
-        (((add, 1, 2), 3), (1, (add, 2, 3)))
-    )
-    assert set(assocsized(add, (1, 2, 3), 1)) == set((((add, 1, 2, 3),),))
-
-
-def test_objects():
     fact(commutative, Add)
     fact(associative, Add)
-    assert tuple(goaleval(eq_assoccomm(add(1, 2, 3), add(3, 1, 2)))({}))
-    assert tuple(goaleval(eq_assoccomm(add(1, 2, 3), add(3, 1, 2)))({}))
 
-    x = var("x")
+    x = var()
 
-    assert (
-        reify(x, tuple(goaleval(eq_assoccomm(add(1, 2, 3), add(1, 2, x)))({}))[0]) == 3
-    )
-
-    assert reify(x, next(goaleval(eq_assoccomm(add(1, 2, 3), add(x, 2, 1)))({}))) == 3
+    assert run(0, True, eq_assoccomm(add(1, 2, 3), add(3, 1, 2))) == (True,)
+    assert run(0, x, eq_assoccomm(add(1, 2, 3), add(1, 2, x))) == (3,)
+    assert run(0, x, eq_assoccomm(add(1, 2, 3), add(x, 2, 1))) == (3,)
 
     v = add(1, 2, 3)
     with variables(v):
         x = add(5, 6)
-        assert reify(v, next(goaleval(eq_assoccomm(v, x))({}))) == x
-
-
-@pytest.mark.xfail(reason="This would work if we flattened first.", strict=True)
-def test_deep_associativity():
-    expr1 = (a, 1, 2, (a, x, 5, 6))
-    expr2 = (a, (a, 1, 2), 3, 4, 5, 6)
-    result = {x: (a, 3, 4)}
-    assert tuple(assocunify(expr1, expr2, {})) == result
-
-
-def test_buildo():
-    x = var("x")
-    assert results(buildo("add", (1, 2, 3), x), {}) == ({x: ("add", 1, 2, 3)},)
-    assert results(buildo(x, (1, 2, 3), ("add", 1, 2, 3)), {}) == ({x: "add"},)
-    assert results(buildo("add", x, ("add", 1, 2, 3)), {}) == ({x: (1, 2, 3)},)
-
-
-def test_op_args():
-    assert op_args(add(1, 2, 3)) == (Add, (1, 2, 3))
-    assert op_args("foo") == (None, None)
-
-
-def test_buildo_object():
-    x = var("x")
-    assert results(buildo(Add, (1, 2, 3), x), {}) == ({x: add(1, 2, 3)},)
-    assert results(buildo(x, (1, 2, 3), add(1, 2, 3)), {}) == ({x: Add},)
-    assert results(buildo(Add, x, add(1, 2, 3)), {}) == ({x: (1, 2, 3)},)
-
-
-def test_eq_comm_object():
-    x = var("x")
-    fact(commutative, Add)
-    fact(associative, Add)
-
-    assert run(0, x, eq_comm(add(1, 2, 3), add(3, 1, x))) == (2,)
-
-    assert set(run(0, x, eq_comm(add(1, 2), x))) == set((add(1, 2), add(2, 1)))
-
-    assert set(run(0, x, eq_assoccomm(add(1, 2, 3), add(1, x)))) == set(
-        (add(2, 3), add(3, 2))
-    )
+        # TODO: There are two more cases here, but they're in tuple form.
+        # See `test_eq_comm_object`.
+        assert x in run(0, v, eq_assoccomm(v, x))

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -20,9 +20,9 @@ from kanren.assoccomm import (
 )
 from kanren.term import operator, arguments, term
 
-a = "assoc_op"
-c = "comm_op"
 x, y = var("x"), var("y")
+
+a, c = "assoc_op", "comm_op"
 fact(associative, a)
 fact(commutative, c)
 
@@ -128,9 +128,9 @@ def test_eq_assoccomm():
     assert results(eqac((1,), (1,)))
     assert results(eqac(x, (1,)))
     assert results(eqac((1,), x))
-    assert results(eqac((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1))))
     assert results((eqac, 1, 1))
     assert results(eqac((a, (a, 1, 2), 3), (a, 1, 2, 3)))
+    assert results(eqac((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1))))
     assert results(eqac((ac, (ac, 1, 2), 3), (ac, 1, 2, 3)))
     assert results(eqac((ac, 3, (ac, 1, 2)), (ac, 1, 2, 3)))
     assert not results(eqac((ac, 1, 1), ("other_op", 1, 1)))
@@ -155,8 +155,19 @@ def test_expr():
 def test_deep_commutativity():
     x, y = var("x"), var("y")
 
+    e1 = ((c, 3, 1),)
+    e2 = ((c, 1, x),)
+
+    assert run(0, x, eq_comm(e1, e2)) == (3,)
+
+    e1 = (2, (c, 3, 1))
+    e2 = (y, (c, 1, x))
+
+    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
+
     e1 = (c, (c, 1, x), y)
     e2 = (c, 2, (c, 3, 1))
+
     assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ from itertools import count
 
 from pytest import raises, mark
 
+from cons import cons
 from unification import var, isvar
 
 from kanren.core import (
@@ -20,6 +21,7 @@ from kanren.core import (
     lallfirst,
     condeseq,
     ifa,
+    ground_order,
 )
 from kanren.util import evalt
 
@@ -250,3 +252,14 @@ def test_ifa():
         eq(x, True),
         ifa(lall(eq(x, True), eq(y, 1)), lall(eq(x, True), eq(y, 2))),
     ) == (1,)
+
+
+def test_ground_order():
+    x, y, z = var(), var(), var()
+    assert run(0, x, ground_order((y, [1, z], 1), x)) == ([1, [1, z], y],)
+    a, b, c = var(), var(), var()
+    assert run(0, (a, b, c), ground_order((y, [1, z], 1), (a, b, c))) == (
+        (1, [1, z], y),
+    )
+    assert run(0, z, ground_order([cons(x, y), (x, y)], z)) == ([(x, y), cons(x, y)],)
+    assert run(0, z, ground_order([(x, y), cons(x, y)], z)) == ([(x, y), cons(x, y)],)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -175,3 +175,36 @@ def results(g, s=None):
 def test_dict():
     x = var()
     assert run(0, x, eq({1: x}, {1: 2})) == (2,)
+
+
+def test_goal_ordering():
+    # Regression test for https://github.com/logpy/logpy/issues/58
+
+    def lefto(q, p, lst):
+        if isvar(lst):
+            raise EarlyGoalError()
+        return ege_membero((q, p), zip(lst, lst[1:]))
+
+    vals = var()
+
+    # Verify the solution can be computed when we specify the execution
+    # ordering.
+    rules_greedy = (
+        lallgreedy,
+        (eq, (var(), var()), vals),
+        (lefto, "green", "white", vals),
+    )
+
+    (solution,) = run(1, vals, rules_greedy)
+    assert solution == ("green", "white")
+
+    # Verify that attempting to compute the "safe" order does not itself cause
+    # the evaluation to fail.
+    rules_greedy = (
+        lall,
+        (eq, (var(), var()), vals),
+        (lefto, "green", "white", vals),
+    )
+
+    (solution,) = run(1, vals, rules_greedy)
+    assert solution == ("green", "white")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,7 @@ from kanren.core import (
     earlysafe,
     lallfirst,
     condeseq,
+    ifa,
 )
 from kanren.util import evalt
 
@@ -224,3 +225,28 @@ def test_goal_ordering():
 
     (solution,) = run(1, vals, rules_greedy)
     assert solution == ("green", "white")
+
+
+def test_ifa():
+    x, y = var(), var()
+
+    assert run(0, (x, y), ifa(lall(eq(x, True), eq(y, 1)), eq(y, 2))) == ((True, 1),)
+    assert run(
+        0, y, eq(x, False), ifa(lall(eq(x, True), eq(y, 1)), lall(eq(y, 2)))
+    ) == (2,)
+    assert (
+        run(
+            0,
+            y,
+            eq(x, False),
+            ifa(lall(eq(x, True), eq(y, 1)), lall(eq(x, True), eq(y, 2))),
+        )
+        == ()
+    )
+
+    assert run(
+        0,
+        y,
+        eq(x, True),
+        ifa(lall(eq(x, True), eq(y, 1)), lall(eq(x, True), eq(y, 2))),
+    ) == (1,)

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from unification import var
 
 from kanren.core import run, conde

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -16,7 +16,7 @@ from kanren.goals import (
     membero,
     rembero,
 )
-from kanren.core import run, eq, goaleval, lall, lallgreedy, EarlyGoalError
+from kanren.core import eq, goaleval, run
 
 x, y, z, w = var("x"), var("y"), var("z"), var("w")
 
@@ -223,39 +223,6 @@ def test_appendo2():
         results = run(2, (x, y, z, w), appendo(x, y, w), appendo(w, z, t))
         for xi, yi, zi, wi in results:
             assert xi + yi + zi == t
-
-
-def test_goal_ordering():
-    # Regression test for https://github.com/logpy/logpy/issues/58
-
-    def lefto(q, p, lst):
-        if isvar(lst):
-            raise EarlyGoalError()
-        return membero((q, p), zip(lst, lst[1:]))
-
-    vals = var()
-
-    # Verify the solution can be computed when we specify the execution
-    # ordering.
-    rules_greedy = (
-        lallgreedy,
-        (eq, (var(), var()), vals),
-        (lefto, "green", "white", vals),
-    )
-
-    (solution,) = run(1, vals, rules_greedy)
-    assert solution == ("green", "white")
-
-    # Verify that attempting to compute the "safe" order does not itself cause
-    # the evaluation to fail.
-    rules_greedy = (
-        lall,
-        (eq, (var(), var()), vals),
-        (lefto, "green", "white", vals),
-    )
-
-    (solution,) = run(1, vals, rules_greedy)
-    assert solution == ("green", "white")
 
 
 def test_rembero():

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -16,7 +16,7 @@ from kanren.goals import (
     rembero,
     permuteo,
 )
-from kanren.core import eq, goaleval, run
+from kanren.core import eq, goaleval, run, conde
 
 
 def results(g, s=None):
@@ -304,3 +304,21 @@ def test_permuteo():
     assert bi_res[3][0] != bi_res[3][1] == [bi_var_2, bi_var_1]
     bi_var_3 = bi_res[4][0][2]
     assert bi_res[4][0] == bi_res[4][1] == [bi_var_1, bi_var_2, bi_var_3]
+
+    assert run(0, x, permuteo((1, 2), (1, 2), no_ident=True)) == ()
+    assert run(0, True, permuteo((1, 2), (2, 1), no_ident=True)) == (True,)
+    assert run(0, x, permuteo((), x, no_ident=True)) == ()
+    assert run(0, x, permuteo(x, (), no_ident=True)) == ()
+    assert run(0, x, permuteo((1,), x, no_ident=True)) == ()
+    assert run(0, x, permuteo(x, (1,), no_ident=True)) == ()
+    assert (1, 2, 3) not in run(0, x, permuteo((1, 2, 3), x, no_ident=True))
+    assert (1, 2, 3) not in run(0, x, permuteo(x, (1, 2, 3), no_ident=True))
+    y = var()
+    assert all(a != b for a, b in run(6, [x, y], permuteo(x, y, no_ident=True)))
+
+    def eq_permute(x, y):
+        return conde([eq(x, y)], [permuteo(a, b) for a, b in zip(x, y)])
+
+    assert run(
+        0, True, permuteo((1, (2, 3)), ((3, 2), 1), inner_eq=eq_permute, no_ident=True)
+    ) == (True,)

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -9,7 +9,6 @@ from kanren.goals import (
     tailo,
     heado,
     appendo,
-    seteq,
     conso,
     nullo,
     itero,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -13,7 +13,7 @@ from cons import cons
 
 from kanren import run, eq, conde, lall
 from kanren.constraints import isinstanceo
-from kanren.graph import applyo, reduceo, map_anyo, walko
+from kanren.graph import applyo, reduceo, map_anyo, walko, mapo
 
 
 class OrderedFunction(object):
@@ -145,6 +145,29 @@ def test_reduceo():
     res = run(2, q_lv, full_math_reduceo(q_lv, 1))
     assert res[0] == etuple(log, etuple(exp, 1))
     assert res[1] == etuple(log, etuple(exp, etuple(log, etuple(exp, 1))))
+
+
+def test_mapo():
+    q_lv = var()
+
+    def blah(x, y):
+        return conde([eq(x, 1), eq(y, "a")], [eq(x, 3), eq(y, "b")])
+
+    assert run(0, q_lv, mapo(blah, [], q_lv)) == ([],)
+    assert run(0, q_lv, mapo(blah, [1, 2, 3], q_lv)) == ()
+    assert run(0, q_lv, mapo(blah, [1, 1, 3], q_lv)) == (["a", "a", "b"],)
+    assert run(0, q_lv, mapo(blah, q_lv, ["a", "a", "b"])) == ([1, 1, 3],)
+
+    exp_res = (
+        [[], []],
+        [[1], ["a"]],
+        [[3], ["b"]],
+        [[1, 1], ["a", "a"]],
+        [[3, 1], ["b", "a"]],
+    )
+
+    a_lv = var()
+    assert run(5, [q_lv, a_lv], mapo(blah, q_lv, a_lv)) == exp_res
 
 
 def test_map_anyo_types():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,7 +4,7 @@ from operator import add, mul
 from functools import partial
 from math import log, exp
 
-from unification import var, unify
+from unification import var, unify, isvar, reify
 
 from etuples.dispatch import rator, rands, apply
 from etuples.core import etuple, ExpressionTuple
@@ -13,7 +13,7 @@ from cons import cons
 
 from kanren import run, eq, conde, lall
 from kanren.constraints import isinstanceo
-from kanren.graph import applyo, reduceo, map_anyo, walko, mapo
+from kanren.graph import applyo, reduceo, map_anyo, walko, mapo, eq_length
 
 
 class OrderedFunction(object):
@@ -170,6 +170,29 @@ def test_mapo():
     assert run(5, [q_lv, a_lv], mapo(blah, q_lv, a_lv)) == exp_res
 
 
+def test_eq_length():
+    q_lv = var()
+
+    res = run(0, q_lv, eq_length([1, 2, 3], q_lv))
+    assert len(res) == 1 and len(res[0]) == 3 and all(isvar(q) for q in res[0])
+
+    res = run(0, q_lv, eq_length(q_lv, [1, 2, 3]))
+    assert len(res) == 1 and len(res[0]) == 3 and all(isvar(q) for q in res[0])
+
+    res = run(0, q_lv, eq_length(cons(1, q_lv), [1, 2, 3]))
+    assert len(res) == 1 and len(res[0]) == 2 and all(isvar(q) for q in res[0])
+
+    v_lv = var()
+    res = run(3, (q_lv, v_lv), eq_length(q_lv, v_lv, default_ConsNull=tuple))
+    assert len(res) == 3 and all(
+        isinstance(a, tuple)
+        and len(a) == len(b)
+        and (len(a) == 0 or a != b)
+        and all(isvar(r) for r in a)
+        for a, b in res
+    )
+
+
 def test_map_anyo_types():
     """Make sure that `applyo` preserves the types between its arguments."""
     q_lv = var()
@@ -218,6 +241,30 @@ def test_map_anyo_misc():
 
     test_res = run(4, q_lv, map_anyo(math_reduceo, q_lv, var("z"), tuple))
     assert all(isinstance(r, tuple) for r in test_res)
+
+    x, y, z = var(), var(), var()
+
+    def test_bin(a, b):
+        return conde([eq(a, 1), eq(b, 2)])
+
+    res = run(10, (x, y), map_anyo(test_bin, x, y, null_type=tuple))
+    exp_res_form = (
+        ((1,), (2,)),
+        ((x, 1), (x, 2)),
+        ((1, 1), (2, 2)),
+        ((x, y, 1), (x, y, 2)),
+        ((1, x), (2, x)),
+        ((x, 1, 1), (x, 2, 2)),
+        ((1, 1, 1), (2, 2, 2)),
+        ((x, y, z, 1), (x, y, z, 2)),
+        ((1, x, 1), (2, x, 2)),
+        ((x, 1, y), (x, 2, y)),
+    )
+
+    for a, b in zip(res, exp_res_form):
+        s = unify(a, b)
+        assert s is not False
+        assert all(isvar(i) for i in reify((x, y, z), s))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sudoku.py
+++ b/tests/test_sudoku.py
@@ -2,8 +2,6 @@
 Based off
 https://github.com/holtchesley/embedded-logic/blob/master/kanren/sudoku.ipynb
 """
-from __future__ import absolute_import
-
 from unification import var
 
 from kanren import run


### PR DESCRIPTION
This PR introduces more of the standard miniKanren goals and rewrites current versions that rely on `EarlyGoalError` and are not able to handle all valid input types (e.g. goals that can't handle logic variables for some or all arguments).

Some new goals:
- [x] `rembero`: a goal representing the relation `l.remove(b); l == out`, where `l` and `out` are sequences and `b` is an element of `l`.
- [x] `mapo`: unlike `map_anyo`, a given binary relation must succeed for *every* corresponding element pair in the given sequences.

Ones that need to be rewritten:
- [x] `appendo`
- [x] `membero`
- [x] `permuteq` (rename to `permuteo`)
- [x] `eq_assoc`
- [x] `eq_comm`
- [x] `eq_assoccomm`