### PR TITLE
Fix associative-commutative relations and the use of term walk groundedness

### DIFF
--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -25,12 +25,15 @@ associative = Relation("associative")
 commutative = Relation("commutative")
 
 
-def flatten_assoc_args(op_predicate, items):
+def flatten_assoc_args(op_predicate, items, shallow=True):
     for i in items:
         if isinstance(i, ConsPair) and op_predicate(car(i)):
             i_cdr = cdr(i)
             if length_hint(i_cdr) > 0:
-                yield from flatten_assoc_args(op_predicate, i_cdr)
+                if shallow:
+                    yield from iter(i_cdr)
+                else:
+                    yield from flatten_assoc_args(op_predicate, i_cdr)
             else:
                 yield i
         else:

--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -214,12 +214,11 @@ def assoc_flatteno(a, a_flat, no_ident=False, null_type=etuple):
 def eq_assoc_args(
     op, a_args, b_args, n=None, inner_eq=eq, no_ident=False, null_type=etuple
 ):
-    """Create a goal that applies associative unification to an operator and two sets of arguments.
+    """Create a goal that applies associative unification to an operator and two sets of arguments.  # noqa: E501
 
-    This is a non-relational utility goal.  It does assumes that the op and at
-    least one set of arguments are ground under the state in which it is
-    evaluated.
-    """  # noqa: E501
+    This is a non-relational utility goal.  It assumes that the op and at least
+    one set of arguments are ground under the state in which it is evaluated.
+    """
     u_args, v_args = var(), var()
 
     def eq_assoc_args_goal(S):
@@ -293,7 +292,7 @@ def eq_assoc_args(
     )
 
 
-def eq_assoc(u, v, n=None, op_predicate=associative, null_type=etuple):
+def eq_assoc(u, v, n=None, op_predicate=associative, null_type=etuple, no_ident=False):
     """Create a goal for associative unification of two terms.
 
     Warning: This goal walks the left-hand argument, `u`, so make that argument
@@ -314,10 +313,10 @@ def eq_assoc(u, v, n=None, op_predicate=associative, null_type=etuple):
     def assoc_args_unique(a, b, op, **kwargs):
         return eq_assoc_args(op, a, b, no_ident=True, null_type=null_type)
 
-    return term_walko(op_predicate, assoc_args_unique, u, v, n=n)
+    return term_walko(op_predicate, assoc_args_unique, u, v, n=n, no_ident=no_ident)
 
 
-def eq_comm(u, v, op_predicate=commutative, null_type=etuple):
+def eq_comm(u, v, op_predicate=commutative, null_type=etuple, no_ident=False):
     """Create a goal for commutative equality.
 
     Warning: This goal walks the left-hand argument, `u`, so make that argument
@@ -339,7 +338,7 @@ def eq_comm(u, v, op_predicate=commutative, null_type=etuple):
     def permuteo_unique(x, y, op, **kwargs):
         return permuteo(x, y, no_ident=True, default_ConsNull=null_type)
 
-    return term_walko(op_predicate, permuteo_unique, u, v)
+    return term_walko(op_predicate, permuteo_unique, u, v, no_ident=no_ident)
 
 
 def eq_assoccomm(u, v, null_type=etuple):

--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -4,29 +4,6 @@ This module provides goals for associative and commutative unification.  It
 accomplishes this through naively trying all possibilities.  This was built to
 be used in the computer algebra systems SymPy and Theano.
 
->>> from kanren import run, var, fact
->>> from kanren.assoccomm import eq_assoccomm as eq
->>> from kanren.assoccomm import commutative, associative
-
->>> # Define some dummy Ops
->>> add = 'add'
->>> mul = 'mul'
-
->>> # Declare that these ops are commutative using the facts system
->>> fact(commutative, mul)
->>> fact(commutative, add)
->>> fact(associative, mul)
->>> fact(associative, add)
-
->>> # Define some wild variables
->>> x, y = var('x'), var('y')
-
->>> # Two expressions to match
->>> pattern = (mul, (add, 1, x), y)                # (1 + x) * y
->>> expr    = (mul, 2, (add, 3, 1))                # 2 * (3 + 1)
-
->>> print(run(0, (x,y), eq(pattern, expr)))
-((3, 2),)
 """
 from collections.abc import Sequence
 from functools import partial
@@ -176,6 +153,10 @@ def eq_assoc_args(
 def eq_assoc(u, v, n=None, op_predicate=associative, null_type=etuple):
     """Create a goal for associative unification of two terms.
 
+    Warning: This goal walks the left-hand argument, `u`, so make that argument
+    the most ground term; otherwise, it may iterate indefinitely when it should
+    actually terminate.
+
     >>> from kanren import run, var, fact
     >>> from kanren.assoccomm import eq_assoc as eq
 
@@ -195,6 +176,10 @@ def eq_assoc(u, v, n=None, op_predicate=associative, null_type=etuple):
 
 def eq_comm(u, v, op_predicate=commutative, null_type=etuple):
     """Create a goal for commutative equality.
+
+    Warning: This goal walks the left-hand argument, `u`, so make that argument
+    the most ground term; otherwise, it may iterate indefinitely when it should
+    actually terminate.
 
     >>> from kanren import run, var, fact
     >>> from kanren.assoccomm import eq_comm as eq
@@ -238,6 +223,10 @@ def assoc_flatten(a, a_flat):
 
 def eq_assoccomm(u, v, null_type=etuple):
     """Construct a goal for associative and commutative unification.
+
+    Warning: This goal walks the left-hand argument, `u`, so make that argument
+    the most ground term; otherwise, it may iterate indefinitely when it should
+    actually terminate.
 
     >>> from kanren.assoccomm import eq_assoccomm as eq
     >>> from kanren.assoccomm import commutative, associative

--- a/kanren/assoccomm.py
+++ b/kanren/assoccomm.py
@@ -10,60 +10,205 @@ from functools import partial
 from operator import eq as equal
 from operator import length_hint
 
-from cons.core import ConsPair, car, cdr
 from etuples import etuple
-from toolz import sliding_window
 from unification import reify, unify, var
 
-from .core import conde, eq, ground_order, lall, succeed
+from .core import Zzz, conde, eq, fail, ground_order, lall, lany, succeed
 from .facts import Relation
-from .goals import itero, permuteo
+from .goals import conso, itero, permuteo
 from .graph import term_walko
-from .term import term
+from .term import TermType, applyo, arguments, operator, term
 
 associative = Relation("associative")
 commutative = Relation("commutative")
 
 
-def flatten_assoc_args(op_predicate, items, shallow=True):
-    for i in items:
-        if isinstance(i, ConsPair) and op_predicate(car(i)):
-            i_cdr = cdr(i)
-            if length_hint(i_cdr) > 0:
-                if shallow:
-                    yield from iter(i_cdr)
+def flatten_assoc_args(op_predicate, term, shallow=True):
+    """Flatten/normalize a term with an associative operator.
+
+    Parameters
+    ----------
+    op_predicate: callable
+        A function used to determine the operators to flatten.
+    items: Sequence
+        The term to flatten.
+    shallow: bool (optional)
+        Indicate whether or not flattening should be done at all depths.
+    """
+
+    if not isinstance(term, TermType):
+        return term
+
+    def _flatten(term):
+        for i in term:
+            if isinstance(i, TermType) and op_predicate(operator(i)):
+                i_cdr = arguments(i)
+                if length_hint(i_cdr) > 0:
+                    if shallow:
+                        yield from iter(i_cdr)
+                    else:
+                        yield from _flatten(i_cdr)
                 else:
-                    yield from flatten_assoc_args(op_predicate, i_cdr)
+                    yield i
             else:
                 yield i
-        else:
-            yield i
+
+    term_type = type(arguments(term))
+    return term_type(_flatten(term))
 
 
-def assoc_args(rator, rands, n, ctor=None):
-    """Produce all associative argument combinations of rator + rands in n-sized rand groupings.
+def partitions(in_seq, n_parts=None, min_size=1, part_fn=lambda x: x):
+    """Generate all partitions of a sequence for given numbers of partitions and minimum group sizes.  # noqa: E501
 
-    >>> from kanren.assoccomm import assoc_args
-    >>> list(assoc_args('op', [1, 2, 3], 2))
-    [[['op', 1, 2], 3], [1, ['op', 2, 3]]]
-    """  # noqa: E501
-    assert n > 0
+    Parameters
+    ----------
+    in_seq: Sequence
+       The sequence to be partitioned.
+    n_parts: int
+       Number of partitions.  `None` means all partitions in `range(2, len(in_seq))`.
+    min_size: int
+       The minimum size of a partition.
+    part_fn: Callable
+       A function applied to every partition.
+    """
 
-    rands_l = list(rands)
+    def partition(seq, res):
+        if (
+            n_parts is None
+            and
+            # We don't want the original sequence
+            len(res) > 0
+        ) or len(res) + 1 == n_parts:
+            yield type(in_seq)(res + [part_fn(seq)])
+
+            if n_parts is not None:
+                return
+
+        for s in range(min_size, len(seq) + 1 - min_size, 1):
+            yield from partition(seq[s:], res + [part_fn(seq[:s])])
+
+    return partition(in_seq, [])
+
+
+def assoc_args(rator, rands, n=None, ctor=None):
+    """Produce all associative argument combinations of rator + rands in n-sized rand groupings.  # noqa: E501
+
+    The normal/canonical form is left-associative, e.g.
+        `(op, 1, 2, 3, 4) == (op, (op, (op, 1, 2), 3), 4)`
+
+    Parameters
+    ----------
+    rator: object
+        The operator that's assumed to be associative.
+    rands: Sequence
+        The operands.
+    n: int (optional)
+        The number of arguments in the resulting `(op,) + output` terms.
+        If not specified, all argument sizes are returned.
+    ctor: callable
+        The constructor to use when each term is created.
+        If not specified, the constructor is inferred from `type(rands)`.
+    """
 
     if ctor is None:
         ctor = type(rands)
 
-    if n == len(rands_l):
+    if len(rands) <= 2 or n is not None and len(rands) <= n:
         yield ctor(rands)
         return
 
-    for i, new_rands in enumerate(sliding_window(n, rands_l)):
-        prefix = rands_l[:i]
-        new_term = term(rator, ctor(new_rands))
-        suffix = rands_l[n + i :]
-        res = ctor(prefix + [new_term] + suffix)
-        yield res
+    def part_fn(x):
+        if len(x) == 1:
+            return x[0]
+        else:
+            return term(rator, ctor(x))
+
+    for p in partitions(rands, n, 1, part_fn=part_fn):
+        yield ctor(p)
+
+
+def assoc_flatteno(a, a_flat, no_ident=False, null_type=etuple):
+    """Construct a goal that flattens/normalizes terms with associative operators.
+
+    The normal/canonical form is left-associative, e.g.
+        `(op, 1, 2, 3, 4) == (op, (op, (op, 1, 2), 3), 4)`
+
+    Parameters
+    ----------
+    a: Var or Sequence
+        The "input" term to flatten.
+    a_flat: Var or Sequence
+        The flattened result, or "output", term.
+    no_ident: bool (optional)
+        Whether or not to fail if no flattening occurs.
+    """
+
+    def assoc_flatteno_goal(S):
+        nonlocal a, a_flat
+
+        a_rf, a_flat_rf = reify((a, a_flat), S)
+
+        if isinstance(a_rf, TermType) and (operator(a_rf),) in associative.facts:
+
+            a_op = operator(a_rf)
+            args_rf = arguments(a_rf)
+
+            def op_pred(sub_op):
+                return sub_op == a_op
+
+            a_flat_rf = term(a_op, flatten_assoc_args(op_pred, args_rf))
+
+            if a_flat_rf == a_rf and no_ident:
+                return
+
+            yield from eq(a_flat, a_flat_rf)(S)
+
+        elif (
+            isinstance(a_flat_rf, TermType)
+            and (operator(a_flat_rf),) in associative.facts
+        ):
+
+            a_flat_op = operator(a_flat_rf)
+            args_rf = arguments(a_flat_rf)
+            assoc_args_iter = assoc_args(a_flat_op, args_rf)
+
+            # TODO: There are much better ways to do this `no_ident` check
+            # (e.g. the `n` argument of `assoc_args` should probably be made to
+            # work for this)
+            yield from lany(
+                fail if no_ident and r is args_rf else applyo(a_flat_op, r, a_rf)
+                for r in assoc_args_iter
+            )(S)
+
+        else:
+
+            op = var()
+            a_rands = var()
+            a_rands_rands = var()
+            a_flat_rands = var()
+            a_flat_rands_rands = var()
+
+            g = conde(
+                [fail if no_ident else eq(a_rf, a_flat_rf)],
+                [
+                    associative(op),
+                    applyo(op, a_rands, a_rf),
+                    applyo(op, a_flat_rands, a_flat_rf),
+                    # There must be at least two rands
+                    conso(var(), a_rands_rands, a_rands),
+                    conso(var(), var(), a_rands_rands),
+                    conso(var(), a_flat_rands_rands, a_flat_rands),
+                    conso(var(), var(), a_flat_rands_rands),
+                    itero(
+                        a_flat_rands, nullo_refs=(a_rands,), default_ConsNull=null_type
+                    ),
+                    Zzz(assoc_flatteno, a_rf, a_flat_rf, no_ident=no_ident),
+                ],
+            )
+
+            yield from g(S)
+
+    return assoc_flatteno_goal
 
 
 def eq_assoc_args(
@@ -98,15 +243,17 @@ def eq_assoc_args(
             u_args_flat = type(u_args_rf)(flatten_assoc_args(op_pred, u_args_rf))
             v_args_flat = type(v_args_rf)(flatten_assoc_args(op_pred, v_args_rf))
 
-            if len(u_args_flat) == len(v_args_flat):
+            u_len, v_len = len(u_args_flat), len(v_args_flat)
+            if u_len == v_len:
                 g = inner_eq(u_args_flat, v_args_flat)
             else:
-                if len(u_args_flat) < len(v_args_flat):
+                if u_len < v_len:
                     sm_args, lg_args = u_args_flat, v_args_flat
+                    grp_sizes = u_len
                 else:
                     sm_args, lg_args = v_args_flat, u_args_flat
+                    grp_sizes = v_len
 
-                grp_sizes = len(lg_args) - len(sm_args) + 1
                 assoc_terms = assoc_args(
                     op_rf, lg_args, grp_sizes, ctor=type(u_args_rf)
                 )
@@ -129,20 +276,13 @@ def eq_assoc_args(
 
                 u_args_flat = list(flatten_assoc_args(partial(equal, op_rf), u_args_rf))
 
-                if n_rf is not None:
-                    arg_sizes = [n_rf]
-                else:
-                    arg_sizes = range(2, len(u_args_flat) + (not no_ident))
-
-                v_ac_args = (
-                    v_ac_arg
-                    for n_i in arg_sizes
+                g = conde(
+                    [inner_eq(v_args_rf, v_ac_arg)]
                     for v_ac_arg in assoc_args(
-                        op_rf, u_args_flat, n_i, ctor=type(u_args_rf)
+                        op_rf, u_args_flat, n_rf, ctor=type(u_args_rf)
                     )
                     if not no_ident or v_ac_arg != u_args_rf
                 )
-                g = conde([inner_eq(v_args_rf, v_ac_arg)] for v_ac_arg in v_ac_args)
 
             yield from g(S)
 
@@ -202,28 +342,6 @@ def eq_comm(u, v, op_predicate=commutative, null_type=etuple):
     return term_walko(op_predicate, permuteo_unique, u, v)
 
 
-def assoc_flatten(a, a_flat):
-    def assoc_flatten_goal(S):
-        nonlocal a, a_flat
-
-        a_rf = reify(a, S)
-
-        if isinstance(a_rf, Sequence) and (a_rf[0],) in associative.facts:
-
-            def op_pred(sub_op):
-                nonlocal S
-                sub_op_rf = reify(sub_op, S)
-                return sub_op_rf == a_rf[0]
-
-            a_flat_rf = type(a_rf)(flatten_assoc_args(op_pred, a_rf))
-        else:
-            a_flat_rf = a_rf
-
-        yield from eq(a_flat, a_flat_rf)(S)
-
-    return assoc_flatten_goal
-
-
 def eq_assoccomm(u, v, null_type=etuple):
     """Construct a goal for associative and commutative unification.
 
@@ -267,6 +385,6 @@ def eq_assoccomm(u, v, null_type=etuple):
         eq_assoccomm_step,
         u,
         v,
-        format_step=assoc_flatten,
+        format_step=assoc_flatteno,
         no_ident=False,
     )

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -176,7 +176,11 @@ def ground_order_seqs(in_seqs, out_seqs, key_fn=shallow_ground_order_key):
         ):
 
             in_seqs_ord = zip(*sorted(zip(*in_seqs_rf), key=partial(key_fn, S)))
-            S_new = unify(list(out_seqs_rf), list(in_seqs_ord), S)
+            S_new = unify(
+                list(out_seqs_rf),
+                [type(j)(i) for i, j in zip(in_seqs_ord, in_seqs_rf)],
+                S,
+            )
 
             if S_new is not False:
                 yield S_new
@@ -251,8 +255,9 @@ def run(n, x, *goals, results_filter=None):
 
 
 def dbgo(*args, msg=None, pdb=False, print_asap=True, trace=True):  # pragma: no cover
-    """Construct a goal that prints reified arguments and, optionally, sets a debug trace."""
+    """Construct a goal that prints reified arguments and, optionally, sets a debug trace."""  # noqa: E501
     from pprint import pprint
+
     from unification import var
 
     trace_var = var("__dbgo_trace")

--- a/kanren/core.py
+++ b/kanren/core.py
@@ -152,6 +152,44 @@ def ground_order(in_args, out_args, key_fn=shallow_ground_order_key):
     return ground_order_goal
 
 
+def ground_order_seqs(in_seqs, out_seqs, key_fn=shallow_ground_order_key):
+    """Construct a non-relational goal that orders lists of sequences based on the groundedness of their corresponding terms.  # noqa: E501
+
+    >>> from unification import var
+    >>> x, y = var('x'), var('y')
+    >>> a, b = var('a'), var('b')
+    >>> run(0, (x, y), ground_order_seqs([(a, b), (b, 2)], [x, y]))
+    (((~b, ~a), (2, ~b)),)
+    """
+
+    def ground_order_seqs_goal(S):
+        nonlocal in_seqs, out_seqs, key_fn
+
+        in_seqs_rf, out_seqs_rf = reify((in_seqs, out_seqs), S)
+
+        if (
+            not any(isinstance(s, str) for s in in_seqs_rf)
+            and reduce(
+                lambda x, y: x == y and y, (length_hint(s, -1) for s in in_seqs_rf)
+            )
+            > 0
+        ):
+
+            in_seqs_ord = zip(*sorted(zip(*in_seqs_rf), key=partial(key_fn, S)))
+            S_new = unify(list(out_seqs_rf), list(in_seqs_ord), S)
+
+            if S_new is not False:
+                yield S_new
+        else:
+
+            S_new = unify(out_seqs_rf, in_seqs_rf, S)
+
+            if S_new is not False:
+                yield S_new
+
+    return ground_order_seqs_goal
+
+
 def ifa(g1, g2):
     """Create a goal operator that returns the first stream unless it fails."""
 

--- a/kanren/graph.py
+++ b/kanren/graph.py
@@ -197,38 +197,25 @@ def walko(
         The map relation used to apply `goal` to a sub-graph.
     """
 
-    def walko_goal(s):
+    rator_in, rands_in, rator_out, rands_out = var(), var(), var(), var()
 
-        nonlocal goal, rator_goal, graph_in, graph_out, null_type, map_rel
+    _walko = partial(
+        walko, goal, rator_goal=rator_goal, null_type=null_type, map_rel=map_rel
+    )
 
-        graph_in_rf, graph_out_rf = reify((graph_in, graph_out), s)
-
-        rator_in, rands_in, rator_out, rands_out = var(), var(), var(), var()
-
-        _walko = partial(
-            walko, goal, rator_goal=rator_goal, null_type=null_type, map_rel=map_rel
-        )
-
-        g = conde(
-            # TODO: Use `Zzz`, if needed.
-            [
-                goal(graph_in_rf, graph_out_rf),
-            ],
-            [
-                lall(
-                    applyo(rator_in, rands_in, graph_in_rf),
-                    applyo(rator_out, rands_out, graph_out_rf),
-                    rator_goal(rator_in, rator_out),
-                    map_rel(_walko, rands_in, rands_out, null_type=null_type),
-                )
-                if rator_goal is not None
-                else map_rel(_walko, graph_in_rf, graph_out_rf, null_type=null_type),
-            ],
-        )
-
-        yield from g(s)
-
-    return walko_goal
+    return conde(
+        [
+            Zzz(goal, graph_in, graph_out),
+        ],
+        [
+            applyo(rator_in, rands_in, graph_in),
+            applyo(rator_out, rands_out, graph_out),
+            Zzz(rator_goal, rator_in, rator_out),
+            Zzz(map_rel, _walko, rands_in, rands_out, null_type=null_type),
+        ]
+        if rator_goal is not None
+        else [Zzz(map_rel, _walko, graph_in, graph_out, null_type=null_type)],
+    )
 
 
 def term_walko(

--- a/kanren/graph.py
+++ b/kanren/graph.py
@@ -3,7 +3,7 @@ from functools import partial
 from etuples import etuple
 from unification import isvar, reify, var
 
-from .core import Zzz, conde, eq, fail, ground_order, lall, succeed
+from .core import Zzz, conde, eq, fail, lall, succeed
 from .goals import conso, nullo
 from .term import applyo
 
@@ -239,13 +239,11 @@ def term_walko(
     should always fail!
     """
 
-    def single_step(s, t):
-        u, v = var(), var()
+    def single_step(u, v):
         u_rator, u_rands = var(), var()
         v_rands = var()
 
         return lall(
-            ground_order((s, t), (u, v)),
             applyo(u_rator, u_rands, u),
             applyo(u_rator, v_rands, v),
             rator_goal(u_rator),
@@ -256,13 +254,11 @@ def term_walko(
             Zzz(rands_goal, u_rands, v_rands, u_rator, **kwargs),
         )
 
-    def term_walko_step(s, t):
+    def term_walko_step(u, v):
         nonlocal rator_goal, rands_goal, null_type
-        u, v = var(), var()
         z, w = var(), var()
 
         return lall(
-            ground_order((s, t), (u, v)),
             format_step(u, w) if format_step is not None else eq(u, w),
             conde(
                 [

--- a/kanren/term.py
+++ b/kanren/term.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta
 from collections.abc import Mapping, Sequence
 
 from cons.core import ConsError, cons
@@ -9,6 +10,25 @@ from unification.variable import isvar
 
 from .core import eq, lall
 from .goals import conso
+
+
+class TermMetaType(ABCMeta):
+    """A meta type that can be used to check for `operator`/`arguments` support."""
+
+    def __instancecheck__(self, o):
+        o_type = type(o)
+        if any(issubclass(o_type, k) for k in operator.funcs.keys() if k[0] != object):
+            return True
+        return False
+
+    def __subclasscheck__(self, o_type):
+        if any(issubclass(o_type, k) for k in operator.funcs.keys() if k[0] != object):
+            return True
+        return False
+
+
+class TermType(metaclass=TermMetaType):
+    pass
 
 
 def applyo(o_rator, o_rands, obj):

--- a/kanren/term.py
+++ b/kanren/term.py
@@ -8,7 +8,7 @@ from etuples import rator as operator
 from unification.core import _reify, _unify, construction_sentinel, reify
 from unification.variable import isvar
 
-from .core import eq, lall
+from .core import eq, lall, shallow_ground_order_key
 from .goals import conso
 
 
@@ -104,3 +104,8 @@ def unify_term(u, v, s):
     if s is not False:
         s = yield _unify(u_args, v_args, s)
     yield s
+
+
+@shallow_ground_order_key.register(Mapping, TermType)
+def shallow_ground_order_key_TermType(S, x):
+    return shallow_ground_order_key(S, cons(operator(x), arguments(x)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydocstyle>=3.0.0
 pytest>=5.0.0
 pytest-cov>=2.6.1
 pytest-html>=1.20.0
+pytest-timeout
 pylint>=2.3.1
 black>=19.3b0; platform.python_implementation!='PyPy'
 diff-cover

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=["kanren"],
     install_requires=[
         "toolz",
-        "cons >= 0.4.0",
+        "cons >= 0.4.2",
         "multipledispatch",
         "etuples >= 0.3.1",
         "logical-unification >= 0.4.1",

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -119,8 +119,10 @@ def test_eq_comm_all_variations():
     }
 
     x = var()
-    res = run(0, x, eq_comm((comm_op, 1, (comm_op, 2, (comm_op, 3, 4))), x))
-    assert sorted(res, key=str) == sorted(expected_res, key=str)
+
+    for s in expected_res:
+        res = run(0, x, eq_comm(s, x))
+        assert sorted(res, key=str) == sorted(expected_res, key=str)
 
 
 def test_eq_comm_unground():
@@ -495,8 +497,10 @@ def test_eq_assoc_all_variations():
         (assoc_op, 1, 2, (assoc_op, 3, 4)),
         (assoc_op, 1, 2, 3, 4),
     }
-    res = run(0, x, eq_assoc((assoc_op, 1, 2, 3, 4), x))
-    assert sorted(res, key=str) == sorted(expected_res, key=str)
+
+    for s in expected_res:
+        res = run(0, x, eq_assoc(s, x))
+        assert sorted(res, key=str) == sorted(expected_res, key=str)
 
 
 def test_eq_assoc_unground():
@@ -716,7 +720,7 @@ def test_eq_assoccomm_all_variations():
     x = var()
 
     # TODO: Use four arguments to see real associative variation.
-    exp_res = set(
+    expected_res = set(
         (
             (ac, 1, 3, 2),
             (ac, 1, 2, 3),
@@ -738,9 +742,13 @@ def test_eq_assoccomm_all_variations():
             (ac, (ac, 2, 1), 3),
         )
     )
-    assert set(run(0, x, eq_assoccomm((ac, 1, (ac, 2, 3)), x))) == exp_res
-    assert set(run(0, x, eq_assoccomm((ac, 1, 3, 2), x))) == exp_res
-    assert set(run(0, x, eq_assoccomm((ac, 2, (ac, 3, 1)), x))) == exp_res
+
+    for s in expected_res:
+        res = run(0, x, eq_assoccomm(s, x))
+        # TODO FIXME: Avoid the extra identity result
+        res = list(res)
+        res.remove(s)
+        assert sorted(res, key=str) == sorted(expected_res, key=str)
 
 
 def test_eq_assoccomm_unground():

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -140,11 +140,33 @@ def test_flatten_assoc_args():
 
     res = list(
         flatten_assoc_args(
-            op_pred, [[1, 2, op], 3, [op, 4, [op, [op]]], [op, 5], 6, op, 7]
+            op_pred,
+            [[1, 2, op], 3, [op, 4, [op, [op]]], [op, 5], 6, op, 7],
+            shallow=False,
         )
     )
     exp_res = [[1, 2, op], 3, 4, [op], 5, 6, op, 7]
     assert res == exp_res
+
+    exa_col = (1, 2, ("b", 3, ("a", 4, 5)), ("c", 6, 7), ("a", ("a", 8, 9), 10))
+    assert list(flatten_assoc_args(lambda x: x == "a", exa_col, shallow=False)) == [
+        1,
+        2,
+        ("b", 3, ("a", 4, 5)),
+        ("c", 6, 7),
+        8,
+        9,
+        10,
+    ]
+
+    assert list(flatten_assoc_args(lambda x: x == "a", exa_col, shallow=True)) == [
+        1,
+        2,
+        ("b", 3, ("a", 4, 5)),
+        ("c", 6, 7),
+        ("a", 8, 9),
+        10,
+    ]
 
 
 def test_assoc_args():

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -29,14 +29,14 @@ def results(g, s=None):
 
 
 def test_eq_comm():
-    x, y, z = var(), var(), var()
-
     commutative.facts.clear()
     commutative.index.clear()
 
     comm_op = "comm_op"
 
     fact(commutative, comm_op)
+
+    x, y, z = var(), var(), var()
 
     assert run(0, True, eq_comm(1, 1)) == (True,)
     assert run(0, True, eq_comm((comm_op, 1, 2, 3), (comm_op, 1, 2, 3))) == (True,)
@@ -58,20 +58,6 @@ def test_eq_comm():
     assert not run(0, True, eq_comm((3, comm_op, 2, 1), (comm_op, 1, 2, 3)))
     assert not run(0, True, eq_comm((comm_op, 1, 2, 1), (comm_op, 1, 2, 3)))
     assert not run(0, True, eq_comm(("op", 1, 2, 3), (comm_op, 1, 2, 3)))
-
-    # Test for variable args
-    res = run(4, (x, y), eq_comm(x, y))
-    exp_res_form = (
-        (etuple(comm_op, x, y), etuple(comm_op, y, x)),
-        (x, y),
-        (etuple(etuple(comm_op, x, y)), etuple(etuple(comm_op, y, x))),
-        (etuple(comm_op, x, y, z), etuple(comm_op, x, z, y)),
-    )
-
-    for a, b in zip(res, exp_res_form):
-        s = unify(a, b)
-        assert s is not False
-        assert all(isvar(i) for i in reify((x, y, z), s))
 
     # Make sure it can unify single elements
     assert (3,) == run(0, x, eq_comm((comm_op, 1, 2, 3), (comm_op, 2, x, 1)))
@@ -112,9 +98,53 @@ def test_eq_comm():
     e2 = (y, (comm_op, 1, x))
     assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
 
-    e1 = (comm_op, 2, (comm_op, 3, 1))
-    e2 = (comm_op, (comm_op, 1, x), y)
-    assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
+
+def test_eq_comm_all_variations():
+    commutative.facts.clear()
+    commutative.index.clear()
+
+    comm_op = "comm_op"
+
+    fact(commutative, comm_op)
+
+    expected_res = {
+        (comm_op, 1, (comm_op, 2, (comm_op, 3, 4))),
+        (comm_op, 1, (comm_op, 2, (comm_op, 4, 3))),
+        (comm_op, 1, (comm_op, (comm_op, 3, 4), 2)),
+        (comm_op, 1, (comm_op, (comm_op, 4, 3), 2)),
+        (comm_op, (comm_op, 2, (comm_op, 3, 4)), 1),
+        (comm_op, (comm_op, 2, (comm_op, 4, 3)), 1),
+        (comm_op, (comm_op, (comm_op, 3, 4), 2), 1),
+        (comm_op, (comm_op, (comm_op, 4, 3), 2), 1),
+    }
+
+    x = var()
+    res = run(0, x, eq_comm((comm_op, 1, (comm_op, 2, (comm_op, 3, 4))), x))
+    assert sorted(res, key=str) == sorted(expected_res, key=str)
+
+
+def test_eq_comm_unground():
+    commutative.facts.clear()
+    commutative.index.clear()
+
+    comm_op = "comm_op"
+
+    fact(commutative, comm_op)
+
+    x, y, z = var(), var(), var()
+    # Test for variable args
+    res = run(4, (x, y), eq_comm(x, y))
+    exp_res_form = (
+        (etuple(comm_op, x, y), etuple(comm_op, y, x)),
+        (x, y),
+        (etuple(etuple(comm_op, x, y)), etuple(etuple(comm_op, y, x))),
+        (etuple(comm_op, x, y, z), etuple(comm_op, x, z, y)),
+    )
+
+    for a, b in zip(res, exp_res_form):
+        s = unify(a, b)
+        assert s is not False
+        assert all(isvar(i) for i in reify((x, y, z), s))
 
 
 @pytest.mark.xfail(reason="`applyo`/`buildo` needs to be a constraint.", strict=True)
@@ -423,14 +453,6 @@ def test_eq_assoc():
     expr2 = (assoc_op, 1, 2, (assoc_op, x, 5, 6))
     assert run(0, x, eq_assoc(expr1, expr2, n=2)) == ((assoc_op, 3, 4),)
 
-    # TODO: Need groundedness ordering for this
-    # res = run(0, x, eq_assoc(x, (assoc_op, 1, 2, 3), n=2))
-    # assert res == (
-    #     (assoc_op, (assoc_op, 1, 2), 3),
-    #     (assoc_op, 1, 2, 3),
-    #     (assoc_op, 1, (assoc_op, 2, 3)),
-    # )
-
 
 @pytest.mark.xfail(strict=False)
 def test_eq_assoc_cons():
@@ -458,21 +480,20 @@ def test_eq_assoc_all_variations():
     fact(associative, assoc_op)
 
     x = var()
+    # Normalized, our results are left-associative, i.e.
+    # (assoc_op, (assoc_op, (assoc_op, 1, 2), 3), 4) == (assoc_op, 1, 2, 3, 4)
     expected_res = {
-        # Normalized, our results are left-associative, i.e.
-        # (assoc_op, (assoc_op, (assoc_op, 1, 2), 3), 4),
-        # is equal to the following:
-        (assoc_op, 1, 2, 3, 4),
-        (assoc_op, (assoc_op, 1, 2), 3, 4),
-        (assoc_op, 1, (assoc_op, 2, 3), 4),
-        (assoc_op, 1, 2, (assoc_op, 3, 4)),
-        (assoc_op, (assoc_op, 1, 2, 3), 4),
-        (assoc_op, 1, (assoc_op, 2, 3, 4)),
+        (assoc_op, (assoc_op, (assoc_op, 1, 2), 3), 4),  # Missing
+        (assoc_op, (assoc_op, 1, (assoc_op, 2, 3)), 4),  # Missing
         (assoc_op, (assoc_op, 1, 2), (assoc_op, 3, 4)),
-        (assoc_op, (assoc_op, (assoc_op, 1, 2), 3), 4),
-        (assoc_op, (assoc_op, 1, (assoc_op, 2, 3)), 4),
-        (assoc_op, 1, (assoc_op, (assoc_op, 2, 3), 4)),
-        (assoc_op, 1, (assoc_op, 2, (assoc_op, 3, 4))),
+        (assoc_op, (assoc_op, 1, 2), 3, 4),
+        (assoc_op, (assoc_op, 1, 2, 3), 4),
+        (assoc_op, 1, (assoc_op, (assoc_op, 2, 3), 4)),  # Missing
+        (assoc_op, 1, (assoc_op, 2, (assoc_op, 3, 4))),  # Missing
+        (assoc_op, 1, (assoc_op, 2, 3), 4),
+        (assoc_op, 1, (assoc_op, 2, 3, 4)),
+        (assoc_op, 1, 2, (assoc_op, 3, 4)),
+        (assoc_op, 1, 2, 3, 4),
     }
     res = run(0, x, eq_assoc((assoc_op, 1, 2, 3, 4), x))
     assert sorted(res, key=str) == sorted(expected_res, key=str)
@@ -806,7 +827,7 @@ def test_eq_assoccomm_objects():
 
 @pytest.mark.xfail(strict=False)
 @pytest.mark.timeout(5)
-def test_eq_assoccom_scaling():
+def test_eq_assoccomm_scaling():
 
     commutative.index.clear()
     commutative.facts.clear()
@@ -821,7 +842,6 @@ def test_eq_assoccom_scaling():
     fact(commutative, mul)
     fact(associative, mul)
 
-    # TODO: Make a low-depth term inequal (e.g. inequal at base)
     import random
 
     from tests.utils import generate_term
@@ -830,6 +850,7 @@ def test_eq_assoccom_scaling():
 
     test_graph = generate_term((add, mul), range(4), 5)
 
+    # Make a low-depth term inequal (e.g. inequal at base):
     # Change the root operator
     test_graph_2 = list(test_graph)
     test_graph_2[0] = add if test_graph_2[0] == mul else mul

--- a/tests/test_assoccomm.py
+++ b/tests/test_assoccomm.py
@@ -39,8 +39,8 @@ def test_eq_comm():
     assert run(0, True, eq_comm((comm_op, 1, 2, 3), (comm_op, 1, 2, 3))) == (True,)
 
     assert run(0, True, eq_comm((comm_op, 3, 2, 1), (comm_op, 1, 2, 3))) == (True,)
-    assert run(0, y, eq_comm((comm_op, 3, y, 1), (comm_op, 1, 2, 3))) == (2,)
-    assert run(0, (x, y), eq_comm((comm_op, x, y, 1), (comm_op, 1, 2, 3))) == (
+    assert run(0, y, eq_comm((comm_op, 1, 2, 3), (comm_op, 3, y, 1))) == (2,)
+    assert run(0, (x, y), eq_comm((comm_op, 1, 2, 3), (comm_op, x, y, 1))) == (
         (2, 3),
         (3, 2),
     )
@@ -86,9 +86,9 @@ def test_eq_comm():
     assert expected_res == set(
         run(0, (x, y, z), eq_comm((comm_op, 1, 2, 3), (comm_op, x, y, z)))
     )
-    assert expected_res == set(
-        run(0, (x, y, z), eq_comm((comm_op, x, y, z), (comm_op, 1, 2, 3)))
-    )
+    # assert expected_res == set(
+    #     run(0, (x, y, z), eq_comm((comm_op, x, y, z), (comm_op, 1, 2, 3)))
+    # )
     assert expected_res == set(
         run(
             0,
@@ -97,23 +97,20 @@ def test_eq_comm():
         )
     )
 
-    e1 = (comm_op, (comm_op, 1, x), y)
-    e2 = (comm_op, 2, (comm_op, 3, 1))
+    e1 = (comm_op, 2, (comm_op, 3, 1))
+    e2 = (comm_op, (comm_op, 1, x), y)
     assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
 
     e1 = ((comm_op, 3, 1),)
     e2 = ((comm_op, 1, x),)
-
     assert run(0, x, eq_comm(e1, e2)) == (3,)
 
     e1 = (2, (comm_op, 3, 1))
     e2 = (y, (comm_op, 1, x))
-
     assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
 
-    e1 = (comm_op, (comm_op, 1, x), y)
-    e2 = (comm_op, 2, (comm_op, 3, 1))
-
+    e1 = (comm_op, 2, (comm_op, 3, 1))
+    e2 = (comm_op, (comm_op, 1, x), y)
     assert run(0, (x, y), eq_comm(e1, e2)) == ((3, 2),)
 
 
@@ -296,12 +293,12 @@ def test_eq_assoc():
         (assoc_op, 1, (assoc_op, 2, 3)),
     )
 
-    res = run(0, x, eq_assoc(x, (assoc_op, 1, 2, 3), n=2))
-    assert res == (
-        (assoc_op, (assoc_op, 1, 2), 3),
-        (assoc_op, 1, 2, 3),
-        (assoc_op, 1, (assoc_op, 2, 3)),
-    )
+    # res = run(0, x, eq_assoc(x, (assoc_op, 1, 2, 3), n=2))
+    # assert res == (
+    #     (assoc_op, (assoc_op, 1, 2), 3),
+    #     (assoc_op, 1, 2, 3),
+    #     (assoc_op, 1, (assoc_op, 2, 3)),
+    # )
 
     y, z = var(), var()
 
@@ -322,7 +319,7 @@ def test_eq_assoc():
         assert all(isvar(i) for i in reify((x, y, z), s))
 
     # Make sure it works with `cons`
-    res = run(0, (x, y), eq_assoc(cons(x, y), (assoc_op, 1, 2, 3)))
+    res = run(0, (x, y), eq_assoc((assoc_op, 1, 2, 3), cons(x, y)))
     assert res == (
         (assoc_op, ((assoc_op, 1, 2), 3)),
         (assoc_op, (1, 2, 3)),
@@ -337,8 +334,8 @@ def test_eq_assoc():
     # run(1, (x, y), eq_assoc(cons(x, y), (x, z), op_predicate=associative_2))
 
     # Nested expressions should work now
-    expr1 = (assoc_op, 1, 2, (assoc_op, x, 5, 6))
-    expr2 = (assoc_op, (assoc_op, 1, 2), 3, 4, 5, 6)
+    expr1 = (assoc_op, (assoc_op, 1, 2), 3, 4, 5, 6)
+    expr2 = (assoc_op, 1, 2, (assoc_op, x, 5, 6))
     assert run(0, x, eq_assoc(expr1, expr2, n=2)) == ((assoc_op, 3, 4),)
 
 
@@ -402,7 +399,7 @@ def test_eq_assoccomm():
 
     assert run(0, True, eq_assoccomm(1, 1)) == (True,)
     assert run(0, True, eq_assoccomm((1,), (1,))) == (True,)
-    assert run(0, True, eq_assoccomm(x, (1,))) == (True,)
+    # assert run(0, True, eq_assoccomm(x, (1,))) == (True,)
     assert run(0, True, eq_assoccomm((1,), x)) == (True,)
 
     # Assoc only
@@ -444,12 +441,16 @@ def test_eq_assoccomm():
     assert set(run(0, x, eq_assoccomm((ac, 1, 3, 2), x))) == exp_res
     assert set(run(0, x, eq_assoccomm((ac, 2, (ac, 3, 1)), x))) == exp_res
     # LHS variations
-    assert set(run(0, x, eq_assoccomm(x, (ac, 1, (ac, 2, 3))))) == exp_res
+    # assert set(run(0, x, eq_assoccomm(x, (ac, 1, (ac, 2, 3))))) == exp_res
 
-    assert run(0, (x, y), eq_assoccomm((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1)))) == (
+    assert run(0, (x, y), eq_assoccomm((ac, 2, (ac, 3, 1)), (ac, (ac, 1, x), y))) == (
         (2, 3),
         (3, 2),
     )
+    # assert run(0, (x, y), eq_assoccomm((ac, (ac, 1, x), y), (ac, 2, (ac, 3, 1)))) == (
+    #     (2, 3),
+    #     (3, 2),
+    # )
 
     assert run(0, True, eq_assoccomm((ac, (ac, 1, 2), 3), (ac, 1, 2, 3))) == (True,)
     assert run(0, True, eq_assoccomm((ac, 3, (ac, 1, 2)), (ac, 1, 2, 3))) == (True,)
@@ -502,8 +503,8 @@ def test_assoccomm_algebra():
 
     x, y = var(), var()
 
-    pattern = (mul, (add, 1, x), y)  # (1 + x) * y
-    expr = (mul, 2, (add, 3, 1))  # 2 * (3 + 1)
+    pattern = (mul, 2, (add, 3, 1))  # 2 * (3 + 1)
+    expr = (mul, (add, 1, x), y)  # (1 + x) * y
 
     assert run(0, (x, y), eq_assoccomm(pattern, expr)) == ((3, 2),)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,7 @@ from kanren.core import (
     eq,
     fail,
     ground_order,
+    ground_order_seqs,
     ifa,
     lall,
     lany,
@@ -275,3 +276,25 @@ def test_ground_order():
     assert res == ([(x, y), cons(x, y)],)
     res = run(0, z, ground_order([(x, y), cons(x, y)], z))
     assert res == ([(x, y), cons(x, y)],)
+
+
+def test_ground_order_seq():
+
+    x, y, z = var(), var(), var()
+    a, b = var(), var()
+    res = run(0, (x, y), ground_order_seqs([a, (b, 2)], [x, y]))
+    assert res == ((a, (b, 2)),)
+    res = run(0, (x, y), ground_order_seqs([(a,), (b, 2)], [x, y]))
+    assert res == (((a,), (b, 2)),)
+    res = run(0, (x, y), ground_order_seqs([(a, b), (b, 2)], [x, y]))
+    assert res == (((b, a), (2, b)),)
+    res = run(0, (x, y), ground_order_seqs([(b, 2), (a, b)], [x, y]))
+    assert res == (((2, b), (b, a)),)
+    res = run(0, (x, y, z), ground_order_seqs([(b, 2), (a, b), (0, 1)], [x, y, z]))
+    assert res == (((2, b), (b, a), (1, 0)),)
+    res = run(0, (x, y), ground_order_seqs([(), ()], [x, y]))
+    assert res == (((), ()),)
+    res = run(0, (x, y), ground_order_seqs([(a, (1, b)), (b, 2)], [x, y]))
+    assert res == ((((1, b), a), (2, b)),)
+    res = run(0, (x, y), ground_order_seqs(["abc", "def"], [x, y]))
+    assert res == (("abc", "def"),)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -18,6 +18,7 @@ from kanren.core import (
     ldisj,
     ldisj_seq,
     run,
+    shallow_ground_order_key,
     succeed,
 )
 
@@ -248,11 +249,28 @@ def test_ifa():
 
 def test_ground_order():
     x, y, z = var(), var(), var()
+
+    assert shallow_ground_order_key({}, x) > shallow_ground_order_key({}, (x, y))
+    assert shallow_ground_order_key({}, cons(x, y)) > shallow_ground_order_key(
+        {}, (x, y)
+    )
+    assert shallow_ground_order_key({}, cons(1, 2)) < shallow_ground_order_key(
+        {}, (1, 2, 3, 4, y)
+    )
+    assert shallow_ground_order_key({}, cons(1, 2)) == shallow_ground_order_key(
+        {}, (1, 2, 3, 4)
+    )
+    assert shallow_ground_order_key({}, (x, y)) == shallow_ground_order_key(
+        {}, (x, y, z)
+    )
+
     assert run(0, x, ground_order((y, [1, z], 1), x)) == ([1, [1, z], y],)
+
     a, b, c = var(), var(), var()
     assert run(0, (a, b, c), ground_order((y, [1, z], 1), (a, b, c))) == (
         (1, [1, z], y),
     )
+
     res = run(0, z, ground_order([cons(x, y), (x, y)], z))
     assert res == ([(x, y), cons(x, y)],)
     res = run(0, z, ground_order([(x, y), cons(x, y)], z))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -298,3 +298,5 @@ def test_ground_order_seq():
     assert res == ((((1, b), a), (2, b)),)
     res = run(0, (x, y), ground_order_seqs(["abc", "def"], [x, y]))
     assert res == (("abc", "def"),)
+    res = run(0, (x, y), ground_order_seqs([[1, 2], (1, 2)], [x, y]))
+    assert res == (([1, 2], (1, 2)),)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -71,7 +71,7 @@ def single_math_reduceo(expanded_term, reduced_term):
 
 math_reduceo = partial(reduceo, single_math_reduceo)
 
-term_walko = partial(
+walko_term = partial(
     walko,
     rator_goal=eq,
     null_type=ExpressionTuple,
@@ -413,11 +413,11 @@ def test_walko(test_input, test_output):
     """Test `walko` with fully ground terms (i.e. no logic variables)."""
 
     q_lv = var()
-    term_walko_fp = partial(reduceo, partial(term_walko, single_math_reduceo))
+    walko_term_fp = partial(reduceo, partial(walko_term, single_math_reduceo))
     test_res = run(
         len(test_output),
         q_lv,
-        term_walko_fp(test_input, q_lv),
+        walko_term_fp(test_input, q_lv),
         results_filter=toolz.unique,
     )
 
@@ -438,7 +438,7 @@ def test_walko_reverse():
     """Test `walko` in "reverse" (i.e. specify the reduced form and generate the un-reduced form)."""  # noqa: E501
     q_lv = var("q")
 
-    test_res = run(2, q_lv, term_walko(math_reduceo, q_lv, 5))
+    test_res = run(2, q_lv, walko_term(math_reduceo, q_lv, 5))
     assert test_res == (
         etuple(log, etuple(exp, 5)),
         etuple(log, etuple(exp, etuple(log, etuple(exp, 5)))),
@@ -446,7 +446,7 @@ def test_walko_reverse():
     assert all(e.eval_obj == 5.0 for e in test_res)
 
     # Make sure we get some variety in the results
-    test_res = run(2, q_lv, term_walko(math_reduceo, q_lv, etuple(mul, 2, 5)))
+    test_res = run(2, q_lv, walko_term(math_reduceo, q_lv, etuple(mul, 2, 5)))
     assert test_res == (
         # Expansion of the term's root
         etuple(add, 5, 5),
@@ -460,7 +460,7 @@ def test_walko_reverse():
     assert all(e.eval_obj == 10.0 for e in test_res)
 
     r_lv = var("r")
-    test_res = run(4, [q_lv, r_lv], term_walko(math_reduceo, q_lv, r_lv))
+    test_res = run(4, [q_lv, r_lv], walko_term(math_reduceo, q_lv, r_lv))
     expect_res = (
         [etuple(add, 1, 1), etuple(mul, 2, 1)],
         [etuple(log, etuple(exp, etuple(add, 1, 1))), etuple(mul, 2, 1)],

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -3,7 +3,7 @@ from cons.core import ConsType
 from etuples import etuple
 from unification import reify, unify, var
 
-from kanren.core import run
+from kanren.core import run, shallow_ground_order_key
 from kanren.term import TermType, applyo, arguments, operator, term
 from tests.utils import Add, Node, Operator
 
@@ -87,3 +87,16 @@ def test_TermType():
     assert not isinstance([1, 2], TermType)
     assert not isinstance(ConsType, TermType)
     assert not issubclass(type(ConsType), TermType)
+
+
+def test_shallow_ground_order():
+
+    x, y, z = var(), var(), var()
+
+    assert shallow_ground_order_key({}, x) > shallow_ground_order_key({}, Add(x, y))
+    assert shallow_ground_order_key({}, cons(x, y)) > shallow_ground_order_key(
+        {}, Add(x, y)
+    )
+    assert shallow_ground_order_key({}, Add(x, y)) == shallow_ground_order_key(
+        {}, Add(x, y, z)
+    )

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -83,8 +83,10 @@ def test_unifiable_with_term():
 def test_TermType():
     assert issubclass(type(Add(1, 2)), TermType)
     assert isinstance(Add(1, 2), TermType)
-    assert not issubclass(type([1, 2]), TermType)
-    assert not isinstance([1, 2], TermType)
+    # assert not issubclass(type([1, 2]), TermType)
+    # assert not isinstance([1, 2], TermType)
+    assert issubclass(type([1, 2]), TermType)
+    assert isinstance([1, 2], TermType)
     assert not isinstance(ConsType, TermType)
     assert not issubclass(type(ConsType), TermType)
 

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -3,66 +3,8 @@ from etuples import etuple
 from unification import reify, unify, var
 
 from kanren.core import run
-from kanren.term import applyo, arguments, operator, term, unifiable_with_term
-
-
-@unifiable_with_term
-class Node(object):
-    def __init__(self, op, args):
-        self.op = op
-        self.args = args
-
-    def __eq__(self, other):
-        return (
-            type(self) == type(other)
-            and self.op == other.op
-            and self.args == other.args
-        )
-
-    def __hash__(self):
-        return hash((type(self), self.op, self.args))
-
-    def __str__(self):
-        return "%s(%s)" % (self.op.name, ", ".join(map(str, self.args)))
-
-    __repr__ = __str__
-
-
-class Operator(object):
-    def __init__(self, name):
-        self.name = name
-
-
-Add = Operator("add")
-Mul = Operator("mul")
-
-
-def add(*args):
-    return Node(Add, args)
-
-
-def mul(*args):
-    return Node(Mul, args)
-
-
-class Op(object):
-    def __init__(self, name):
-        self.name = name
-
-
-@arguments.register(Node)
-def arguments_Node(t):
-    return t.args
-
-
-@operator.register(Node)
-def operator_Node(t):
-    return t.op
-
-
-@term.register(Operator, (list, tuple))
-def term_Op(op, args):
-    return Node(op, args)
+from kanren.term import applyo, arguments, operator, term
+from tests.utils import Add, Node, Operator
 
 
 def test_applyo():
@@ -103,21 +45,35 @@ def test_applyo():
 
 def test_applyo_object():
     x = var()
-    assert run(0, x, applyo(Add, (1, 2, 3), x)) == (add(1, 2, 3),)
-    assert run(0, x, applyo(x, (1, 2, 3), add(1, 2, 3))) == (Add,)
-    assert run(0, x, applyo(Add, x, add(1, 2, 3))) == ((1, 2, 3),)
+    assert run(0, x, applyo(Add, (1, 2, 3), x)) == (Add(1, 2, 3),)
+    assert run(0, x, applyo(x, (1, 2, 3), Add(1, 2, 3))) == (Add,)
+    assert run(0, x, applyo(Add, x, Add(1, 2, 3))) == ((1, 2, 3),)
+
+
+def test_term_dispatch():
+
+    t = Node(Add, (1, 2))
+
+    assert arguments(t) == (1, 2)
+    assert operator(t) == Add
+    assert term(operator(t), arguments(t)) == t
 
 
 def test_unifiable_with_term():
-    add = Operator("add")
-    t = Node(add, (1, 2))
+    from kanren.term import unifiable_with_term
 
-    assert arguments(t) == (1, 2)
-    assert operator(t) == add
-    assert term(operator(t), arguments(t)) == t
+    @unifiable_with_term
+    class NewNode(Node):
+        pass
+
+    class NewOperator(Operator):
+        def __call__(self, *args):
+            return NewNode(self, args)
+
+    NewAdd = NewOperator("newadd")
 
     x = var()
-    s = unify(Node(add, (1, x)), Node(add, (1, 2)), {})
+    s = unify(NewNode(NewAdd, (1, x)), NewNode(NewAdd, (1, 2)), {})
 
     assert s == {x: 2}
-    assert reify(Node(add, (1, x)), s) == Node(add, (1, 2))
+    assert reify(NewNode(NewAdd, (1, x)), s) == NewNode(NewAdd, (1, 2))

--- a/tests/test_term.py
+++ b/tests/test_term.py
@@ -1,9 +1,10 @@
 from cons import cons
+from cons.core import ConsType
 from etuples import etuple
 from unification import reify, unify, var
 
 from kanren.core import run
-from kanren.term import applyo, arguments, operator, term
+from kanren.term import TermType, applyo, arguments, operator, term
 from tests.utils import Add, Node, Operator
 
 
@@ -77,3 +78,12 @@ def test_unifiable_with_term():
 
     assert s == {x: 2}
     assert reify(NewNode(NewAdd, (1, x)), s) == NewNode(NewAdd, (1, 2))
+
+
+def test_TermType():
+    assert issubclass(type(Add(1, 2)), TermType)
+    assert isinstance(Add(1, 2), TermType)
+    assert not issubclass(type([1, 2]), TermType)
+    assert not isinstance([1, 2], TermType)
+    assert not isinstance(ConsType, TermType)
+    assert not issubclass(type(ConsType), TermType)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+import random
+
 from kanren.term import arguments, operator
 
 
@@ -58,3 +60,29 @@ def operator_Node(t):
 # @term.register(Operator, Sequence)
 # def term_Operator(op, args):
 #     return Node(op, args)
+
+
+def generate_term(ops, args, i=10, gen_fn=None):
+
+    if gen_fn is not None:
+
+        gen_res = gen_fn(ops, args, i)
+
+        if gen_res is not None:
+            return gen_res
+
+    g_op = random.choice(ops)
+
+    if i > 0:
+        num_sub_graphs = len(args) // 2
+    else:
+        num_sub_graphs = 0
+
+    g_args = random.sample(args, len(args) - num_sub_graphs)
+    g_args += [
+        generate_term(ops, args, i=i - 1, gen_fn=gen_fn) for s in range(num_sub_graphs)
+    ]
+
+    random.shuffle(g_args)
+
+    return [g_op] + list(g_args)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,60 @@
+from kanren.term import arguments, operator
+
+
+class Node(object):
+    def __init__(self, op, args):
+        self.op = op
+        self.args = args
+
+    def __eq__(self, other):
+        return (
+            type(self) == type(other)
+            and self.op == other.op
+            and self.args == other.args
+        )
+
+    def __hash__(self):
+        return hash((type(self), self.op, self.args))
+
+    def __str__(self):
+        return "%s(%s)" % (self.op.name, ", ".join(map(str, self.args)))
+
+    __repr__ = __str__
+
+
+class Operator(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __call__(self, *args):
+        return Node(self, args)
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.name == other.name
+
+    def __hash__(self):
+        return hash((type(self), self.name))
+
+    def __str__(self):
+        return self.name
+
+    __repr__ = __str__
+
+
+Add = Operator("add")
+Mul = Operator("mul")
+
+
+@arguments.register(Node)
+def arguments_Node(t):
+    return t.args
+
+
+@operator.register(Node)
+def operator_Node(t):
+    return t.op
+
+
+# @term.register(Operator, Sequence)
+# def term_Operator(op, args):
+#     return Node(op, args)


### PR DESCRIPTION
`ground_order` doesn't really order terms in a way that avoids infinite recursion in `term_walko` (e.g. when called by the `kanren.assoccomm` goals).  There should be a way to handle this&mdash;at least better than it currently does.

This PR is replacing #27.