### PR TITLE
use pypi-publish gh action release branch

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.pypi_secret }}


### PR DESCRIPTION
The master branch of the gh-action-pypi-publish has been [sunset](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#-master-branch-sunset-), they recommend migrating to the release/v1 branch