### PR TITLE
Remove unnecessary typing-extensions dependency

### DIFF
--- a/kanren/core.py
+++ b/kanren/core.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Iterable,
     Iterator,
+    Literal,
     MutableMapping,
     Optional,
     Tuple,
@@ -16,7 +17,6 @@ from typing import (
 
 from cons.core import ConsPair
 from toolz import interleave, take
-from typing_extensions import Literal
 from unification import isvar, reify, unify
 from unification.core import isground
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "etuples >= 0.3.1",
     "logical-unification >= 0.4.1",
     "toolz",
-    "typing_extensions",
 ]
 
 [project.urls]


### PR DESCRIPTION
`typing.Literal` was added in Python 3.8, and we require >=3.9, so `typing-extensions` is unneeded.